### PR TITLE
Hotfix/activesupport-removal

### DIFF
--- a/expressir.gemspec
+++ b/expressir.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = %w[expressir]
 
   spec.add_runtime_dependency "thor", "~> 1.0"
-  spec.add_runtime_dependency "activesupport", "~> 5.0"
   spec.add_runtime_dependency "antlr4-runtime", "~> 0.2.12"
   spec.add_development_dependency "nokogiri", "~> 1.10"
 


### PR DESCRIPTION
lutaml/expressir#20 removed activesupport dependency because of the conflicts it introduces. 