### PR TITLE
Use (x86_64/aarch64)-linux-gnu target platform for native extensions instead of (x86_64/aarch64)-linux

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -68,7 +68,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: ${{ env.BUNDLER_VER }}
-          bundler-cache: true
+          # Rice gem has issues with bundler cache
+          # more info https://github.com/lutaml/expressir/runs/2097658383?check_suite_focus=true#step:7:2126
+          # but it is not the only issue
+          bundler-cache: false
+
+      - name: Bundle
+        run: bundle install --jobs 4 --retry 3
 
       - name: Process cache
         uses: actions/cache@v3
@@ -98,10 +104,9 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@master
         with:
-          ruby-version: '3.0'
-          # bundler-cache: true important to not use cache because it leads to "cannot find -lrice"
-          # more info https://github.com/lutaml/expressir/runs/2097658383?check_suite_focus=true#step:7:2126
+          ruby-version: '3.1'
           bundler: ${{ env.BUNDLER_VER }}
+          bundler-cache: false
 
       - name: Bundle
         run: bundle install --jobs 4 --retry 3
@@ -130,9 +135,8 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@master
         with:
-          ruby-version: '3.0'
-          # bundler-cache: true important to not use cache because it leads to "cannot find -lrice"
-          # more info https://github.com/lutaml/expressir/runs/2097658383?check_suite_focus=true#step:7:2126
+          ruby-version: '3.1'
+          bundler-cache: false
           bundler: ${{ env.BUNDLER_VER }}
 
       - name: Bundle
@@ -169,7 +173,7 @@ jobs:
         uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: false
           bundler: ${{ env.BUNDLER_VER }}
 
       - name: Checkout
@@ -208,7 +212,7 @@ jobs:
         uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: false
           bundler: ${{ env.BUNDLER_VER }}
 
       - name: Checkout
@@ -246,7 +250,7 @@ jobs:
         uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: false
           bundler: ${{ env.BUNDLER_VER }}
 
       - name: Checkout
@@ -284,7 +288,7 @@ jobs:
         uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: false
           bundler: ${{ env.BUNDLER_VER }}
 
       - name: Checkout

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,8 +2,14 @@ name: rake
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - .github/workflows/release.yml
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
@@ -114,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ linux, windows, darwin ]
+        platform: [ linux-gnu, windows, darwin ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,12 +147,12 @@ jobs:
           sudo swapon --all --verbose
 
       - name: Build gem with native extension
-        run: bundle exec rake gem:${{ matrix.host }}
+        run: bundle exec rake gem:${{ matrix.platform }}
 
       - name: Package gem with native extension
         uses: actions/upload-artifact@v3
         with:
-          name: pkg-${{ matrix.host }}
+          name: pkg-${{ matrix.platform }}
           path: pkg/*.gem
 
   verify-ruby:
@@ -227,8 +233,8 @@ jobs:
           ruby bin/rspec
           cat .rspec_status || echo ".rspec_status was not found"
 
-  verify-linux:
-    name: verify Linux binary gem on ruby-${{ matrix.ruby }}
+  verify-linux-gnu:
+    name: verify Linux (gnu) binary gem on ruby-${{ matrix.ruby }}
     needs: pack
     runs-on: ubuntu-latest
     strategy:
@@ -252,11 +258,11 @@ jobs:
       - name: Download packaged gem
         uses: actions/download-artifact@v3
         with:
-         name: pkg-linux
+         name: pkg-linux-gnu
          path: pkg
 
       - name: Install binary gem
-        run: gem install -l pkg/expressir-*-$(ruby -e "puts RUBY_PLATFORM").gem
+        run: gem install -l pkg/expressir-*-$(ruby -e "puts RUBY_PLATFORM")-gnu.gem
 
       - name: Verify
         run: |
@@ -271,8 +277,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-# Ruby 3.1 fails
-# https://github.com/lutaml/expressir/issues/103
       matrix:
         ruby: [ '3.2', '3.1', '3.0', '2.7' ]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
           chmod 0600 ~/.gem/credentials
           gem signin
           for gem in pkg/*.gem; do gem push $gem -V; done
+          sleep(5)
 
   verify:
     name: Verify published gem on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }} # unfortunatelly cannot keep this condition on job level
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
           gem install gem-release
           gem bump --version ${{ github.event.inputs.next_version }} --tag --push
 
@@ -41,12 +41,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ linux, windows, darwin ]
+        platform: [ linux-gnu, windows, darwin ]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: main # https://github.com/actions/checkout/issues/439#issuecomment-830862188
 
       - uses: ruby/setup-ruby@master
         with:
@@ -56,14 +55,22 @@ jobs:
 
       - run: bundle install --jobs 4 --retry 3
 
-      # build gem WITHOUT pre-built native extension
-      - run: gem build expressir.gemspec
+      - name: Build gem and save version
+        if: matrix.platform == 'linux-gnu'
+        run: |
+          gem build expressir.gemspec | grep -o 'Version: .*' | awk '{print $2}' > version
 
-      - if: matrix.host == 'linux'
+      - if: matrix.platform == 'linux-gnu'
         uses: actions/upload-artifact@v3
         with:
           name: pkg-ruby
           path: expressir-*.gem
+
+      - if: matrix.platform == 'linux-gnu'
+        uses: actions/upload-artifact@v3
+        with:
+          name: version
+          path: version
 
       - name: Enable swap
         run: |
@@ -74,11 +81,11 @@ jobs:
           sudo swapon --all --verbose
 
       # build gem WITH pre-built native extension
-      - run: bundle exec rake gem:${{ matrix.host }}
+      - run: bundle exec rake gem:${{ matrix.platform }}
 
       - uses: actions/upload-artifact@v3
         with:
-          name: pkg-${{ matrix.host }}
+          name: pkg-${{ matrix.platform }}
           path: pkg/*.gem
 
   publish:
@@ -92,7 +99,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: pkg-linux
+          name: pkg-linux-gnu
           path: pkg
 
       - uses: actions/download-artifact@v3
@@ -109,12 +116,11 @@ jobs:
         with:
           ruby-version: '3.1'
 
-      - run: ls -l pkg/
-
       - name: Publish to rubygems.org
         env:
           RUBYGEMS_API_KEY: ${{ secrets.LUTAML_CI_RUBYGEMS_API_KEY }}
         run: |
+          ls -l pkg/
           mkdir -p ~/.gem
           cat > ~/.gem/credentials << EOF
           ---
@@ -123,3 +129,51 @@ jobs:
           chmod 0600 ~/.gem/credentials
           gem signin
           for gem in pkg/*.gem; do gem push $gem -V; done
+
+  verify:
+    name: Verify published gem on ${{ matrix.os }}
+    needs: publish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - name: Install Ruby
+        uses: ruby/setup-ruby@master
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+          bundler: ${{ env.BUNDLER_VER }}
+
+      - name: Download version
+        uses: actions/download-artifact@v3
+        with:
+         name: version
+
+      - name: Install gem
+        run: gem install expressir -v $(cat version)
+
+      - name: Verify
+        run: expressir version
+
+  verify-alpine:
+    name: Verify published gem on alpine
+    needs: publish
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.17
+    steps:
+      - name: Install packages
+        run: apk --no-cache add bash build-base git ruby-dev gcc g++ automake
+
+      - name: Download version
+        uses: actions/download-artifact@v3
+        with:
+         name: version
+
+      - name: Install gem
+        run: gem install expressir -v $(cat version)
+
+      - name: Verify
+        run: expressir version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: main # https://github.com/actions/checkout/issues/439#issuecomment-830862188
 
       - uses: ruby/setup-ruby@master
         with:

--- a/expressir.gemspec
+++ b/expressir.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = "expressir"
   spec.version       = Expressir::VERSION
   spec.authors       = ["Ribose Inc."]
-  spec.email         = ["open.source@ribose.com'"]
+  spec.email         = ["open.source@ribose.com"]
 
   spec.summary       = "ISO EXPRESS parser and tools in Ruby."
   spec.description   = "Expressir (“EXPRESS in Ruby”) is a Ruby parser for EXPRESS and a set of Ruby tools for accessing ISO EXPRESS data models."

--- a/lib/expressir/version.rb
+++ b/lib/expressir/version.rb
@@ -1,3 +1,3 @@
 module Expressir
-  VERSION = "1.3.0.pre.4".freeze
+  VERSION = "1.3.0".freeze
 end

--- a/lib/expressir/version.rb
+++ b/lib/expressir/version.rb
@@ -1,3 +1,3 @@
 module Expressir
-  VERSION = "1.2.11".freeze
+  VERSION = "1.3.0.pre.3".freeze
 end

--- a/lib/expressir/version.rb
+++ b/lib/expressir/version.rb
@@ -1,3 +1,3 @@
 module Expressir
-  VERSION = "1.3.0.pre.3".freeze
+  VERSION = "1.3.0.pre.4".freeze
 end


### PR DESCRIPTION
Rubygems/bundler allow  ```(x86_64/aarch64)-linux-gnu```, ```(x86_64/aarch64)-linux-musl```, ```(x86_64/aarch64)-linux``` target platform for native extensions.

When  ```(x86_64/aarch64)-linux-musl``` is not available  Ruby loads ```(x86_64/aarch64)-linux``` on Alpine Linux.
Previous versions of CI for this gem optimistically used rake-compiler defaul that created ```(x86_64/aarch64)-linux``` extension although in most cases it was not compatible with musl environment even with gcompat package installed.

So in this PR native extension target is changed to ```(x86_64/aarch64)-linux-gnu``` .  On Alpine Linux bundler/Rubygems build bantive extension from sources.

There is another issue (#105) that calls for publishing ```(x86_64/aarch64)-linux-musl``` native extension.