### PR TITLE
Fix for #164

### DIFF
--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -275,7 +275,7 @@ module Expressir
         end
         rule(:procedureId) { simpleId.as(:procedureId) }
         rule(:procedureRef) { procedureId.as(:procedureRef) }
-        rule(:qualifiableFactor) { (attributeRef | constantFactor | functionCall | generalRef | population).as(:qualifiableFactor) }
+        rule(:qualifiableFactor) { (functionCall | attributeRef | constantFactor | generalRef | population).as(:qualifiableFactor) }
         rule(:qualifiedAttribute) { (tSELF >> groupQualifier >> attributeQualifier).as(:qualifiedAttribute) }
         rule(:qualifier) { (attributeQualifier | groupQualifier | indexQualifier).as(:qualifier) }
         rule(:queryExpression) do

--- a/spec/syntax/remark.yaml
+++ b/spec/syntax/remark.yaml
@@ -253,9 +253,11 @@ schemas:
         remarks:
         - function query scope - function query
         aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: remark_schema.remark_function.remark_variable
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: remark_variable
+            base_path: remark_schema.remark_function.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: :TRUE
@@ -343,9 +345,11 @@ schemas:
         remarks:
         - rule query scope - rule query
         aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: remark_schema.remark_rule.remark_variable
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: remark_variable
+            base_path: remark_schema.remark_rule.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: :TRUE
@@ -463,9 +467,11 @@ schemas:
         remarks:
         - procedure query scope - procedure query
         aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: remark_schema.remark_procedure.remark_variable
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: remark_variable
+            base_path: remark_schema.remark_procedure.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: :TRUE

--- a/spec/syntax/remark_formatted.exp
+++ b/spec/syntax/remark_formatted.exp
@@ -43,7 +43,7 @@ FUNCTION remark_function(remark_parameter : STRING) : BOOLEAN;
     ;
   --"remark_repeat" function repeat scope - function repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
   --"remark_query" function query scope - function query
   );
 END_FUNCTION;
@@ -66,7 +66,7 @@ RULE remark_rule FOR (remark_entity);
     ;
   --"remark_repeat" rule repeat scope - rule repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
   --"remark_query" rule query scope - rule query
   );
 WHERE
@@ -91,7 +91,7 @@ PROCEDURE remark_procedure(remark_parameter : STRING);
     ;
   --"remark_repeat" procedure repeat scope - procedure repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
   --"remark_query" procedure query scope - procedure query
   );
 END_PROCEDURE;

--- a/spec/syntax/syntax.yaml
+++ b/spec/syntax/syntax.yaml
@@ -1633,8 +1633,10 @@ schemas:
       statements:
       - _class: Expressir::Model::Statements::Case
         expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
           labels:
@@ -1647,8 +1649,10 @@ schemas:
       statements:
       - _class: Expressir::Model::Statements::Case
         expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
           labels:
@@ -1667,8 +1671,10 @@ schemas:
       statements:
       - _class: Expressir::Model::Statements::Case
         expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
           labels:
@@ -1683,8 +1689,10 @@ schemas:
       statements:
       - _class: Expressir::Model::Statements::Case
         expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
           labels:
@@ -3258,11 +3266,15 @@ schemas:
         _class: Expressir::Model::Expressions::BinaryExpression
         operator: :COMBINE
         operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: test2
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
     - _class: Expressir::Model::Declarations::Variable
       id: in_expression
       type:
@@ -3373,8 +3385,10 @@ schemas:
       type:
         _class: Expressir::Model::DataTypes::Boolean
       expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
     - _class: Expressir::Model::Declarations::Variable
       id: group_reference_expression
       type:
@@ -3382,8 +3396,10 @@ schemas:
       expression:
         _class: Expressir::Model::References::GroupReference
         ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         entity:
           _class: Expressir::Model::References::SimpleReference
           id: test2
@@ -3394,8 +3410,10 @@ schemas:
       expression:
         _class: Expressir::Model::References::IndexReference
         ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         index1:
           _class: Expressir::Model::Literals::Integer
           value: '1'
@@ -3406,8 +3424,10 @@ schemas:
       expression:
         _class: Expressir::Model::References::IndexReference
         ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         index1:
           _class: Expressir::Model::Literals::Integer
           value: '1'
@@ -3421,8 +3441,10 @@ schemas:
       expression:
         _class: Expressir::Model::References::AttributeReference
         ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
         attribute:
           _class: Expressir::Model::References::SimpleReference
           id: test2
@@ -3502,8 +3524,10 @@ schemas:
         _class: Expressir::Model::Expressions::QueryExpression
         id: test
         aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: test2
+          _class: Expressir::Model::Expressions::FunctionCall
+          function:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
         expression:
           _class: Expressir::Model::Literals::Logical
           value: :TRUE

--- a/spec/syntax/syntax_formatted.exp
+++ b/spec/syntax/syntax_formatted.exp
@@ -560,13 +560,13 @@ PROCEDURE statements;
     test.test2 := TRUE;
   END_PROCEDURE;
   PROCEDURE case_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     TRUE :
@@ -574,13 +574,13 @@ PROCEDURE statements;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
-    CASE test OF
+    CASE test() OF
     TRUE, TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     OTHERWISE :
@@ -878,7 +878,7 @@ PROCEDURE expressions;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;
     and_parenthesis_or_expression : BOOLEAN := TRUE AND (FALSE OR TRUE);
-    combine_expression : BOOLEAN := test || test2;
+    combine_expression : BOOLEAN := test() || test2();
     in_expression : BOOLEAN := TRUE IN [TRUE];
     like_expression : BOOLEAN := 'xxx' LIKE 'xxx';
     aggregate_initializer_expression : BOOLEAN := [4];
@@ -886,16 +886,16 @@ PROCEDURE expressions;
     complex_aggregate_initializer_expression : BOOLEAN := [4 + 2];
     complex_repeated_aggregate_initializer_expression : BOOLEAN := [4 + 2:4 + 2];
     call_expression : BOOLEAN := parameter_function(TRUE);
-    simple_reference_expression : BOOLEAN := test;
-    group_reference_expression : BOOLEAN := test\test2;
-    index_reference_expression : BOOLEAN := test[1];
-    index2_reference_expression : BOOLEAN := test[1:9];
-    attribute_reference_expression : BOOLEAN := test.test2;
+    simple_reference_expression : BOOLEAN := test();
+    group_reference_expression : BOOLEAN := test()\test2;
+    index_reference_expression : BOOLEAN := test()[1];
+    index2_reference_expression : BOOLEAN := test()[1:9];
+    attribute_reference_expression : BOOLEAN := test().test2;
     lt_lt_interval_expression : BOOLEAN := {1 < 5 < 9};
     lte_lt_interval_expression : BOOLEAN := {1 <= 5 < 9};
     lt_lte_interval_expression : BOOLEAN := {1 < 5 <= 9};
     lte_lte_interval_expression : BOOLEAN := {1 <= 5 <= 9};
-    query_expression : BOOLEAN := QUERY(test <* test2 | TRUE);
+    query_expression : BOOLEAN := QUERY(test <* test2() | TRUE);
   END_LOCAL;
 END_PROCEDURE;
 

--- a/spec/syntax/syntax_hyperlink_formatted.exp
+++ b/spec/syntax/syntax_hyperlink_formatted.exp
@@ -560,13 +560,13 @@ PROCEDURE statements;
     test.test2 := TRUE;
   END_PROCEDURE;
   PROCEDURE case_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     TRUE :
@@ -574,13 +574,13 @@ PROCEDURE statements;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
-    CASE test OF
+    CASE test() OF
     TRUE, TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
-    CASE test OF
+    CASE test() OF
     TRUE :
       ;
     OTHERWISE :
@@ -878,7 +878,7 @@ PROCEDURE expressions;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;
     and_parenthesis_or_expression : BOOLEAN := TRUE AND (FALSE OR TRUE);
-    combine_expression : BOOLEAN := test || test2;
+    combine_expression : BOOLEAN := test() || test2();
     in_expression : BOOLEAN := TRUE IN [TRUE];
     like_expression : BOOLEAN := 'xxx' LIKE 'xxx';
     aggregate_initializer_expression : BOOLEAN := [4];
@@ -886,16 +886,16 @@ PROCEDURE expressions;
     complex_aggregate_initializer_expression : BOOLEAN := [4 + 2];
     complex_repeated_aggregate_initializer_expression : BOOLEAN := [4 + 2:4 + 2];
     call_expression : BOOLEAN := {{{<<express:syntax_schema.parameter_function,parameter_function>>}}}(TRUE);
-    simple_reference_expression : BOOLEAN := test;
-    group_reference_expression : BOOLEAN := test\test2;
-    index_reference_expression : BOOLEAN := test[1];
-    index2_reference_expression : BOOLEAN := test[1:9];
-    attribute_reference_expression : BOOLEAN := test.test2;
+    simple_reference_expression : BOOLEAN := test();
+    group_reference_expression : BOOLEAN := test()\test2;
+    index_reference_expression : BOOLEAN := test()[1];
+    index2_reference_expression : BOOLEAN := test()[1:9];
+    attribute_reference_expression : BOOLEAN := test().test2;
     lt_lt_interval_expression : BOOLEAN := {1 < 5 < 9};
     lte_lt_interval_expression : BOOLEAN := {1 <= 5 < 9};
     lt_lte_interval_expression : BOOLEAN := {1 < 5 <= 9};
     lte_lte_interval_expression : BOOLEAN := {1 <= 5 <= 9};
-    query_expression : BOOLEAN := QUERY(test <* test2 | TRUE);
+    query_expression : BOOLEAN := QUERY(test <* test2() | TRUE);
   END_LOCAL;
 END_PROCEDURE;
 


### PR DESCRIPTION
Expressions of the form "NOT some_func()" were not parsing properly.

Some test data had to be regenerated because the change in ordering of variations in the `qualifiableFactor` rule caused the parser to produce a different result.  This happens because multiple ambiguities in the grammar exist, which would normally be resolved with logic to distinguish what references are referencing.  (The previous parser had no such logic either)
