### PR TITLE
Fix parser bug

### DIFF
--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -340,7 +340,7 @@ module Expressir
         rule(:simpleExpression) { (term >> (addLikeOp.as(:operator) >> term).as(:item).repeat.as(:rhs)).as(:simpleExpression) }
         rule(:simpleFactor) do
           (
-            aggregateInitializer | entityConstructor | interval | queryExpression | simpleFactorExpression |
+            simpleFactorExpression | aggregateInitializer | entityConstructor | interval | queryExpression |
             simpleFactorUnaryExpression | enumerationReference
           ).as(:simpleFactor)
         end


### PR DESCRIPTION
Expressions of the form "func_call(param)[1]" were failing

This appears to resolve all issues with the .exp files in iso-10303