### PR TITLE
Fix CONSTANT can be parsed properly when the function calls have () o…

### DIFF
--- a/lib/expressir/express/formatter.rb
+++ b/lib/expressir/express/formatter.rb
@@ -873,12 +873,17 @@ module Expressir
       end
 
       def format_expressions_function_call(node)
-        [
-          format(node.function),
-          "(",
-          node.parameters.map { |x| format(x) }.join(", "),
-          ")",
-        ].join("")
+        params = if node.parameters.nil?
+                   []
+                 else
+                   [
+                     "(",
+                     node.parameters.map { |x| format(x) }.join(", "),
+                     ")",
+                   ]
+                 end
+
+        [format(node.function), params].flatten.join("")
       end
 
       def format_expressions_interval(node)

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -50,7 +50,7 @@ module Expressir
         end
         rule(:abstractSupertype) { (tABSTRACT >> tSUPERTYPE >> op_delim).as(:abstractSupertype) }
         rule(:actualParameterList) do
-          (op_leftparen >> (parameter >> (op_comma >> parameter).repeat).as(:listOf_parameter) >> op_rightparen)
+          (op_leftparen >> (parameter >> (op_comma >> parameter).repeat).as(:listOf_parameter).maybe >> op_rightparen)
             .as(:actualParameterList)
         end
         rule(:addLikeOp) { (op_plus | op_minus | tOR | tXOR).as(:addLikeOp) }
@@ -340,7 +340,7 @@ module Expressir
         rule(:simpleExpression) { (term >> (addLikeOp.as(:operator) >> term).as(:item).repeat.as(:rhs)).as(:simpleExpression) }
         rule(:simpleFactor) do
           (
-            simpleFactorExpression | aggregateInitializer | entityConstructor | interval | queryExpression |
+            simpleFactorExpression | aggregateInitializer | entityConstructor | interval | queryExpression | stringLiteral |
             simpleFactorUnaryExpression | enumerationReference
           ).as(:simpleFactor)
         end

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -204,6 +204,8 @@ module Expressir
       end
 
       def node_find(node, path)
+        return nil if node.is_a?(String)
+
         if node.is_a?(Enumerable)
           node.find { |item| item.find(path) }
         else

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -1062,7 +1062,7 @@ module Expressir
         ctx__actual_parameter_list = ctx.actual_parameter_list
 
         function = visit_if(ctx__built_in_function || ctx__function_ref)
-        parameters = visit_if(ctx__actual_parameter_list, [])
+        parameters = visit_if(ctx__actual_parameter_list, nil)
 
         Model::Expressions::FunctionCall.new(
           function: function,

--- a/lib/expressir/liquid/expressions/function_call_drop.rb
+++ b/lib/expressir/liquid/expressions/function_call_drop.rb
@@ -14,7 +14,7 @@ module Expressir
         end
 
         def parameters
-          return [] unless @model.parameters
+          return nil unless @model.parameters
 
           @model.parameters.map do |item|
             drop_klass_by_model(item)

--- a/lib/expressir/model/expressions/function_call.rb
+++ b/lib/expressir/model/expressions/function_call.rb
@@ -12,7 +12,7 @@ module Expressir
         # @option options [Array<Expression>] :parameters
         def initialize(options = {})
           @function = options[:function]
-          @parameters = options[:parameters] || []
+          @parameters = options[:parameters]
 
           super
         end

--- a/spec/syntax/remark_formatted.exp
+++ b/spec/syntax/remark_formatted.exp
@@ -43,7 +43,7 @@ FUNCTION remark_function(remark_parameter : STRING) : BOOLEAN;
     ;
   --"remark_repeat" function repeat scope - function repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable | TRUE
   --"remark_query" function query scope - function query
   );
 END_FUNCTION;
@@ -66,7 +66,7 @@ RULE remark_rule FOR (remark_entity);
     ;
   --"remark_repeat" rule repeat scope - rule repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable | TRUE
   --"remark_query" rule query scope - rule query
   );
 WHERE
@@ -91,7 +91,7 @@ PROCEDURE remark_procedure(remark_parameter : STRING);
     ;
   --"remark_repeat" procedure repeat scope - procedure repeat
   END_REPEAT;
-  remark_variable := QUERY(remark_query <* remark_variable() | TRUE
+  remark_variable := QUERY(remark_query <* remark_variable | TRUE
   --"remark_query" procedure query scope - procedure query
   );
 END_PROCEDURE;

--- a/spec/syntax/syntax_formatted.exp
+++ b/spec/syntax/syntax_formatted.exp
@@ -560,13 +560,13 @@ PROCEDURE statements;
     test.test2 := TRUE;
   END_PROCEDURE;
   PROCEDURE case_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     TRUE :
@@ -574,13 +574,13 @@ PROCEDURE statements;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
-    CASE test() OF
+    CASE test OF
     TRUE, TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     OTHERWISE :
@@ -878,7 +878,7 @@ PROCEDURE expressions;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;
     and_parenthesis_or_expression : BOOLEAN := TRUE AND (FALSE OR TRUE);
-    combine_expression : BOOLEAN := test() || test2();
+    combine_expression : BOOLEAN := test || test2;
     in_expression : BOOLEAN := TRUE IN [TRUE];
     like_expression : BOOLEAN := 'xxx' LIKE 'xxx';
     aggregate_initializer_expression : BOOLEAN := [4];
@@ -886,16 +886,16 @@ PROCEDURE expressions;
     complex_aggregate_initializer_expression : BOOLEAN := [4 + 2];
     complex_repeated_aggregate_initializer_expression : BOOLEAN := [4 + 2:4 + 2];
     call_expression : BOOLEAN := parameter_function(TRUE);
-    simple_reference_expression : BOOLEAN := test();
-    group_reference_expression : BOOLEAN := test()\test2;
-    index_reference_expression : BOOLEAN := test()[1];
-    index2_reference_expression : BOOLEAN := test()[1:9];
-    attribute_reference_expression : BOOLEAN := test().test2;
+    simple_reference_expression : BOOLEAN := test;
+    group_reference_expression : BOOLEAN := test\test2;
+    index_reference_expression : BOOLEAN := test[1];
+    index2_reference_expression : BOOLEAN := test[1:9];
+    attribute_reference_expression : BOOLEAN := test.test2;
     lt_lt_interval_expression : BOOLEAN := {1 < 5 < 9};
     lte_lt_interval_expression : BOOLEAN := {1 <= 5 < 9};
     lt_lte_interval_expression : BOOLEAN := {1 < 5 <= 9};
     lte_lte_interval_expression : BOOLEAN := {1 <= 5 <= 9};
-    query_expression : BOOLEAN := QUERY(test <* test2() | TRUE);
+    query_expression : BOOLEAN := QUERY(test <* test2 | TRUE);
   END_LOCAL;
 END_PROCEDURE;
 

--- a/spec/syntax/syntax_hyperlink_formatted.exp
+++ b/spec/syntax/syntax_hyperlink_formatted.exp
@@ -560,13 +560,13 @@ PROCEDURE statements;
     test.test2 := TRUE;
   END_PROCEDURE;
   PROCEDURE case_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     TRUE :
@@ -574,13 +574,13 @@ PROCEDURE statements;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
-    CASE test() OF
+    CASE test OF
     TRUE, TRUE :
       ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
-    CASE test() OF
+    CASE test OF
     TRUE :
       ;
     OTHERWISE :
@@ -878,7 +878,7 @@ PROCEDURE expressions;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;
     and_parenthesis_or_expression : BOOLEAN := TRUE AND (FALSE OR TRUE);
-    combine_expression : BOOLEAN := test() || test2();
+    combine_expression : BOOLEAN := test || test2;
     in_expression : BOOLEAN := TRUE IN [TRUE];
     like_expression : BOOLEAN := 'xxx' LIKE 'xxx';
     aggregate_initializer_expression : BOOLEAN := [4];
@@ -886,16 +886,16 @@ PROCEDURE expressions;
     complex_aggregate_initializer_expression : BOOLEAN := [4 + 2];
     complex_repeated_aggregate_initializer_expression : BOOLEAN := [4 + 2:4 + 2];
     call_expression : BOOLEAN := {{{<<express:syntax_schema.parameter_function,parameter_function>>}}}(TRUE);
-    simple_reference_expression : BOOLEAN := test();
-    group_reference_expression : BOOLEAN := test()\test2;
-    index_reference_expression : BOOLEAN := test()[1];
-    index2_reference_expression : BOOLEAN := test()[1:9];
-    attribute_reference_expression : BOOLEAN := test().test2;
+    simple_reference_expression : BOOLEAN := test;
+    group_reference_expression : BOOLEAN := test\test2;
+    index_reference_expression : BOOLEAN := test[1];
+    index2_reference_expression : BOOLEAN := test[1:9];
+    attribute_reference_expression : BOOLEAN := test.test2;
     lt_lt_interval_expression : BOOLEAN := {1 < 5 < 9};
     lte_lt_interval_expression : BOOLEAN := {1 <= 5 < 9};
     lt_lte_interval_expression : BOOLEAN := {1 < 5 <= 9};
     lte_lte_interval_expression : BOOLEAN := {1 <= 5 <= 9};
-    query_expression : BOOLEAN := QUERY(test <* test2() | TRUE);
+    query_expression : BOOLEAN := QUERY(test <* test2 | TRUE);
   END_LOCAL;
 END_PROCEDURE;
 


### PR DESCRIPTION
…r ('')