### PR TITLE
handle remarks without ending newline

### DIFF
--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -347,7 +347,7 @@ module Expressir
         rule(:supertypeRule) { (tSUPERTYPE >> subtypeConstraint).as(:supertypeRule) }
         rule(:supertypeTerm) { (entityRef | oneOf | op_leftparen >> supertypeExpression >> op_rightparen).as(:supertypeTerm) }
         rule(:syntax) { (spaces.as(:spaces) >> schemaDecl.repeat(1).as(:schemaDecl) >> spaces.as(:trailer)).as(:syntax) }
-        rule(:tailRemark) { (str("--") >> (str("\n").absent? >> any).repeat >> str("\n")).as(:tailRemark) }
+        rule(:tailRemark) { (str("--") >> (str("\n").absent? >> any).repeat >> str("\n").maybe).as(:tailRemark) }
         rule(:term) { (factor >> (multiplicationLikeOp >> factor).as(:item).repeat.as(:rhs)).as(:term) }
         rule(:totalOver) do
           (tTOTAL_OVER >> op_leftparen >> (entityRef >> (op_comma >> entityRef).repeat).as(:listOf_entityRef) >> op_rightparen >> op_delim).as(:totalOver)

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -184,6 +184,21 @@ RSpec.describe Expressir::Express::Parser do
       TEXT
       expect(entity.source).to eq(expected_entity.strip)
     end
+
+    it "parses a file (without_ending_newline.exp)" do |example|
+      print "\n[#{example.description}] "
+      exp_file = Expressir.root_path.join("spec", "syntax", "without_ending_newline.exp")
+      yaml_file = Expressir.root_path.join("spec", "syntax", "without_ending_newline.yaml")
+
+      repo = Expressir::Express::Parser.from_file(
+        exp_file,
+        root_path: Expressir.root_path,
+      )
+      result = repo.to_yaml
+
+      expected_result = File.read(yaml_file)
+      expect(result).to eq(expected_result)
+    end
   end
 
   describe ".from_files" do

--- a/spec/syntax/without_ending_newline.exp
+++ b/spec/syntax/without_ending_newline.exp
@@ -1,0 +1,22 @@
+(*
+   $Id: arm.exp,v 1.10 2009/06/19 09:58:44 philsp Exp $
+   ISO TC184/SC4/WG12 N5836 - ISO/TS 10303-1785 Analysis representation - EXPRESS ARM
+   Supersedes ISO TC184/SC4/WG12 N4550
+*) 
+
+
+SCHEMA Analysis_representation_arm;
+
+USE FROM Foundation_representation_arm;    -- ISO/TS 10303-1006
+
+
+ENTITY Analysis_model
+  SUBTYPE OF (Representation);
+  SELF\Representation.context_of_items : Analysis_representation_context;
+END_ENTITY;
+
+ENTITY Analysis_representation_context
+  SUBTYPE OF (Representation_context);
+END_ENTITY;
+
+END_SCHEMA;  -- Analysis_representation_arm

--- a/spec/syntax/without_ending_newline.yaml
+++ b/spec/syntax/without_ending_newline.yaml
@@ -1,0 +1,43 @@
+---
+_class: Expressir::Model::Repository
+schemas:
+- id: Analysis_representation_arm
+  _class: Expressir::Model::Declarations::Schema
+  file: spec/syntax/without_ending_newline.exp
+  interfaces:
+  - _class: Expressir::Model::Declarations::Interface
+    kind: USE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: Foundation_representation_arm
+  entities:
+  - id: Analysis_model
+    _class: Expressir::Model::Declarations::Entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: Representation
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      kind: EXPLICIT
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: Representation
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: context_of_items
+      type:
+        _class: Expressir::Model::References::SimpleReference
+        id: Analysis_representation_context
+        base_path: Analysis_representation_arm.Analysis_representation_context
+  - id: Analysis_representation_context
+    _class: Expressir::Model::Declarations::Entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: Representation_context


### PR DESCRIPTION
Some `.exp` files in the `stepmod-wg12` repository are missing a trailing newline, which causes `expressir` to fail when parsing these files.

For example, see [modules/analysis_representation](https://github.com/metanorma/iso-10303-stepmod-wg12/blob/main/data/modules/analysis_representation/arm.exp).

needed for https://github.com/metanorma/stepmod-utils/pull/274