### PR TITLE
Performance fixes

### DIFF
--- a/lib/expressir/express/model_visitor.rb
+++ b/lib/expressir/express/model_visitor.rb
@@ -2,9 +2,12 @@ module Expressir
   module Express
     # @abstract
     class ModelVisitor
+      SKIP_ATTRIBUTES = [].freeze
+
       def visit(node)
         node.class.attributes.each_key do |symbol|
           next if ::Expressir::Model::ModelElement::SKIP_ATTRIBUTES.include?(symbol)
+          next if self.class::SKIP_ATTRIBUTES.include?(symbol)
 
           value = node.send(symbol)
 

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -93,9 +93,9 @@ module Expressir
         rule(:boundSpec) { (op_leftbracket >> bound1 >> op_colon >> bound2 >> op_rightbracket).as(:boundSpec) }
         rule(:builtInConstant) { (tCONST_E | tPI | tSELF | op_question_mark).as(:builtInConstant) }
         rule(:builtInFunction) do
-          (tABS | tACOS | tASIN | tATAN | tBLENGTH | tCOS | tEXISTS | tEXP | tFORMAT | tHIBOUND | tHIINDEX | tLENGTH |
-           tLOBOUND | tLOINDEX | tLOG2 | tLOG10 | tLOG | tNVL | tODD | tROLESOF | tSIN | tSIZEOF | tSQRT | tTAN |
-           tTYPEOF | tUSEDIN | tVALUE_IN | tVALUE_UNIQUE | tVALUE).as(:builtInFunction)
+          cts((sABS | sACOS | sASIN | sATAN | sBLENGTH | sCOS | sEXISTS | sEXP | sFORMAT | sHIBOUND | sHIINDEX | sLENGTH |
+            sLOBOUND | sLOINDEX | sLOG2 | sLOG10 | sLOG | sNVL | sODD | sROLESOF | sSIN | sSIZEOF | sSQRT | sTAN |
+            sTYPEOF | sUSEDIN | sVALUE_IN | sVALUE_UNIQUE | sVALUE).as(:builtInFunction))
         end
         rule(:builtInProcedure) { (tINSERT | tREMOVE).as(:builtInProcedure) }
         rule(:caseAction) { ((caseLabel >> (op_comma >> caseLabel).repeat).as(:listOf_caseLabel) >> op_colon >> stmt).as(:caseAction) }
@@ -205,9 +205,9 @@ module Expressir
            (op_decl >> expression).maybe >> op_delim).as(:localVariable)
         end
         rule(:logicalExpression) { expression.as(:logicalExpression) }
-        rule(:logicalLiteral) { (tFALSE | tTRUE | tUNKNOWN).as(:logicalLiteral) }
+        rule(:logicalLiteral) { (cts(sFALSE | sTRUE | sUNKNOWN).as(:logicalLiteral)) }
         rule(:logicalType) { tLOGICAL.as(:logicalType) }
-        rule(:multiplicationLikeOp) { (op_asterisk | op_slash | tDIV | tMOD | tAND | op_double_pipe).as(:multiplicationLikeOp) }
+        rule(:multiplicationLikeOp) { (op_asterisk | op_slash | cts(sDIV | sMOD | sAND) | op_double_pipe).as(:multiplicationLikeOp) }
         rule(:namedTypeOrRename) { (namedTypes >> (tAS >> (entityId | typeId)).maybe).as(:namedTypeOrRename) }
         rule(:namedTypes) { (entityRef | typeRef).as(:namedTypes) }
         rule(:nullStmt) { op_delim.as(:nullStmt) }

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -404,7 +404,8 @@ module Expressir
       def self.from_file(file, skip_references: nil, include_source: nil, root_path: nil) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
         source = File.read file
         cache_key = cache_key(source)
-        do_cache = skip_references.nil? && include_source.nil? && root_path.nil?
+        cache_key += "_true" if skip_references
+        do_cache = include_source.nil? && root_path.nil?
         ret = cache_get(cache_key) if do_cache
         return ret unless ret.nil?
 

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -93,9 +93,9 @@ module Expressir
         rule(:boundSpec) { (op_leftbracket >> bound1 >> op_colon >> bound2 >> op_rightbracket).as(:boundSpec) }
         rule(:builtInConstant) { (tCONST_E | tPI | tSELF | op_question_mark).as(:builtInConstant) }
         rule(:builtInFunction) do
-          cts((sABS | sACOS | sASIN | sATAN | sBLENGTH | sCOS | sEXISTS | sEXP | sFORMAT | sHIBOUND | sHIINDEX | sLENGTH |
-            sLOBOUND | sLOINDEX | sLOG2 | sLOG10 | sLOG | sNVL | sODD | sROLESOF | sSIN | sSIZEOF | sSQRT | sTAN |
-            sTYPEOF | sUSEDIN | sVALUE_IN | sVALUE_UNIQUE | sVALUE).as(:builtInFunction))
+          (tABS | tACOS | tASIN | tATAN | tBLENGTH | tCOS | tEXISTS | tEXP | tFORMAT | tHIBOUND | tHIINDEX | tLENGTH |
+           tLOBOUND | tLOINDEX | tLOG2 | tLOG10 | tLOG | tNVL | tODD | tROLESOF | tSIN | tSIZEOF | tSQRT | tTAN |
+           tTYPEOF | tUSEDIN | tVALUE_IN | tVALUE_UNIQUE | tVALUE).as(:builtInFunction)
         end
         rule(:builtInProcedure) { (tINSERT | tREMOVE).as(:builtInProcedure) }
         rule(:caseAction) { ((caseLabel >> (op_comma >> caseLabel).repeat).as(:listOf_caseLabel) >> op_colon >> stmt).as(:caseAction) }
@@ -205,9 +205,9 @@ module Expressir
            (op_decl >> expression).maybe >> op_delim).as(:localVariable)
         end
         rule(:logicalExpression) { expression.as(:logicalExpression) }
-        rule(:logicalLiteral) { (cts(sFALSE | sTRUE | sUNKNOWN).as(:logicalLiteral)) }
+        rule(:logicalLiteral) { (tFALSE | tTRUE | tUNKNOWN).as(:logicalLiteral) }
         rule(:logicalType) { tLOGICAL.as(:logicalType) }
-        rule(:multiplicationLikeOp) { (op_asterisk | op_slash | cts(sDIV | sMOD | sAND) | op_double_pipe).as(:multiplicationLikeOp) }
+        rule(:multiplicationLikeOp) { (op_asterisk | op_slash | tDIV | tMOD | tAND | op_double_pipe).as(:multiplicationLikeOp) }
         rule(:namedTypeOrRename) { (namedTypes >> (tAS >> (entityId | typeId)).maybe).as(:namedTypeOrRename) }
         rule(:namedTypes) { (entityRef | typeRef).as(:namedTypes) }
         rule(:nullStmt) { op_delim.as(:nullStmt) }

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -3,6 +3,14 @@ require "digest"
 require_relative "error"
 require_relative "parser_cache"
 
+# TODO: how to handle this better?
+# We need to make sure parslet_extensions from plurimath are loaded at this time
+begin
+  require "plurimath/asciimath/parslet_extensions"
+rescue LoadError
+  puts "Could not load parslet_extensions. Performance will be degraded"
+end
+
 module Expressir
   module Express
     class Parser

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -401,7 +401,7 @@ module Expressir
       # @param [Boolean] include_source attach original source code to model elements
       # @return [Model::Repository]
       # @raise [SchemaParseFailure] if the schema file fails to parse
-      def self.from_file(file, skip_references: nil, include_source: nil, root_path: nil) # rubocop:disable Metrics/AbcSize
+      def self.from_file(file, skip_references: nil, include_source: nil, root_path: nil) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
         source = File.read file
         cache_key = cache_key(source)
         do_cache = skip_references.nil? && include_source.nil? && root_path.nil?
@@ -409,7 +409,6 @@ module Expressir
         return ret unless ret.nil?
 
         Expressir::Benchmark.measure_file(file) do
-
           # remove root path from file path
           schema_file = root_path ? Pathname.new(file.to_s).relative_path_from(root_path).to_s : file.to_s
 

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -396,8 +396,9 @@ module Expressir
       def self.from_file(file, skip_references: nil, include_source: nil, root_path: nil) # rubocop:disable Metrics/AbcSize
         source = File.read file
         cache_key = cache_key(source)
-        ret = cache_get(cache_key)
-        return ret if ret
+        do_cache = skip_references.nil? && include_source.nil? && root_path.nil?
+        ret = cache_get(cache_key) if do_cache
+        return ret unless ret.nil?
 
         Expressir::Benchmark.measure_file(file) do
 
@@ -427,7 +428,7 @@ module Expressir
             end
           end
 
-          cache_put(cache_key, @repository)
+          cache_put(cache_key, @repository) if do_cache
           @repository
         end
       end

--- a/lib/expressir/express/parser_cache.rb
+++ b/lib/expressir/express/parser_cache.rb
@@ -9,8 +9,8 @@ module Expressir
         path = cache_path(key)
         return nil unless File.exist?(path)
 
-        File.open(path, "rb") { |f| Marshal.load(f) }
-      rescue
+        File.open(path, "rb") { |f| Marshal.load(f) } # rubocop:disable Security/MarshalLoad
+      rescue # rubocop:disable Style/RescueStandardError
         nil
       end
 

--- a/lib/expressir/express/parser_cache.rb
+++ b/lib/expressir/express/parser_cache.rb
@@ -1,0 +1,29 @@
+require "fileutils"
+
+module Expressir
+  module Express
+    class ParserCache
+      CACHE_DIR = ".cache/express".freeze
+
+      def cache_get(key)
+        path = cache_path(key)
+        return nil unless File.exist?(path)
+
+        File.open(path, "rb") { |f| Marshal.load(f) }
+      rescue
+        nil
+      end
+
+      def cache_put(key, value)
+        FileUtils.mkdir_p(CACHE_DIR)
+        path = cache_path(key)
+
+        File.open(path, "wb") { |f| Marshal.dump(value, f) }
+      end
+
+      def cache_path(key)
+        File.join(CACHE_DIR, key)
+      end
+    end
+  end
+end

--- a/lib/expressir/express/resolve_references_model_visitor.rb
+++ b/lib/expressir/express/resolve_references_model_visitor.rb
@@ -1,6 +1,10 @@
+require 'set'
+
 module Expressir
   module Express
     class ResolveReferencesModelVisitor < ModelVisitor
+      SKIP_ATTRIBUTES = Set.new(%i[source full_source id kind]).freeze
+
       def visit(node)
         if node.is_a? Model::References::SimpleReference
           visit_references_simple_reference(node)

--- a/lib/expressir/express/resolve_references_model_visitor.rb
+++ b/lib/expressir/express/resolve_references_model_visitor.rb
@@ -1,4 +1,4 @@
-require 'set'
+require "set"
 
 module Expressir
   module Express

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -2729,7 +2729,7 @@ module Parslet
       # Fast path for one-byte strings
       return @bytepos if @string.length == @string.bytesize
       # Slow path for multi-byte strings
-      @string[0, @bytepos].length
+      charpos
     end
   end
 end

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -135,6 +135,7 @@ module Expressir
                    ctx.values.map { |item| get_source_pos(item) }
                  when SimpleCtx
                    return nil unless ctx.data.respond_to? :offset
+
                    offset = ctx.data.position.charpos_fast if ctx.data.position.respond_to? :charpos_fast
                    offset = ctx.data.offset if offset.nil?
 
@@ -256,7 +257,8 @@ module Expressir
         when Ctx
           ctx.remarks_cache and return ctx.remarks_cache
           r = []
-          ctx.values.each do |item|
+          # each_value doesn't perform well in the line below on mathematical_functions_schema.exp
+          ctx.values.each do |item| # rubocop:disable Style/HashEachMethods
             r.concat(get_remarks(item))
           end
           ctx.remarks_cache = r
@@ -2728,6 +2730,7 @@ module Parslet
     def charpos_fast
       # Fast path for one-byte strings
       return @bytepos if @string.length == @string.bytesize
+
       # Slow path for multi-byte strings
       charpos
     end

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -5,6 +5,10 @@ module Expressir
     # Base model element
     class ModelElement < Lutaml::Model::Serializable
       SKIP_ATTRIBUTES = %i[parent _class].freeze
+      ATTACH_SKIP_ATTRIBUTES = Set.new(
+        %i[parent _class source id remarks
+                 remark_items base_path operator value
+                 operator1 operator2 name]).freeze
       # :parent is a special attribute that is used to store the parent of the current element
       # It is not a real attribute
       # attribute :parent, ModelElement
@@ -254,6 +258,8 @@ module Expressir
       # @return [nil]
       def attach_parent_to_children
         self.class.attributes.each_pair do |symbol, _lutaml_attr|
+          next if ATTACH_SKIP_ATTRIBUTES.include?(symbol)
+
           value = send(symbol)
 
           case value

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -5,10 +5,6 @@ module Expressir
     # Base model element
     class ModelElement < Lutaml::Model::Serializable
       SKIP_ATTRIBUTES = %i[parent _class].freeze
-      ATTACH_SKIP_ATTRIBUTES = Set.new(
-        %i[parent _class source id remarks
-                 remark_items base_path operator value
-                 operator1 operator2 name]).freeze
       # :parent is a special attribute that is used to store the parent of the current element
       # It is not a real attribute
       # attribute :parent, ModelElement
@@ -258,8 +254,6 @@ module Expressir
       # @return [nil]
       def attach_parent_to_children
         self.class.attributes.each_pair do |symbol, _lutaml_attr|
-          next if ATTACH_SKIP_ATTRIBUTES.include?(symbol)
-
           value = send(symbol)
 
           case value


### PR DESCRIPTION
https://github.com/metanorma/iso-10303/issues/497

- Cache Express grammars on filesystem
- Grammar: add separate rule for anyKeyword negation, which doesn't include space before each keyword
- Expand sum in get_remarks
- Cache remarks in Ctx
- Parslet::Position.charpos_fast optimization
