### PR TITLE
feat: Add InformalPropositionRule as a mechanism to identify informal propositions

### DIFF
--- a/docs/liquid_drops.adoc
+++ b/docs/liquid_drops.adoc
@@ -249,7 +249,7 @@ Attributes:
 `attributes`:: Array of AttributeDrop objects
 `unique_rules`:: Array of UniqueRuleDrop objects
 `where_rules`:: Array of WhereRuleDrop objects
-`informal_propositions`:: Array of RemarkItemDrop objects
+`informal_propositions`:: Array of InformalPropositionRule objects
 
 ==== FunctionDrop
 

--- a/lib/expressir.rb
+++ b/lib/expressir.rb
@@ -98,6 +98,7 @@ module Expressir
       autoload :UniqueRule, "expressir/model/declarations/unique_rule"
       autoload :Variable, "expressir/model/declarations/variable"
       autoload :WhereRule, "expressir/model/declarations/where_rule"
+      autoload :InformalPropositionRule, "expressir/model/declarations/informal_proposition_rule"
     end
 
     module Expressions

--- a/lib/expressir/express/formatter.rb
+++ b/lib/expressir/express/formatter.rb
@@ -91,6 +91,8 @@ module Expressir
           format_declarations_variable(node)
         when Model::Declarations::WhereRule
           format_declarations_where_rule(node)
+        when Model::Declarations::InformalPropositionRule
+          format_declarations_informal_proposition_rule(node)
         when Model::DataTypes::Aggregate
           format_data_types_aggregate(node)
         when Model::DataTypes::Array
@@ -822,6 +824,18 @@ module Expressir
            end,
           format(node.expression),
           ";",
+        ].join
+      end
+
+      def format_declarations_informal_proposition_rule(node)
+        [
+          *if node.id
+             [
+               node.id,
+               ":",
+               " ",
+             ].join
+           end,
         ].join
       end
 
@@ -1629,6 +1643,8 @@ module Expressir
           ].join("\n")
         else
           # Handle tail remarks
+          
+          if remark.include?("rule scope - rule informal proposition")
           [
             "--\"",
             node.path || node.id,

--- a/lib/expressir/express/formatter.rb
+++ b/lib/expressir/express/formatter.rb
@@ -1661,7 +1661,7 @@ module Expressir
         # Add tagged remarks
         if node.class.method_defined?(:remarks) && !@no_remarks &&
             !node.remarks.nil?
-          remarks.concat(node.remarks.map do |remark|
+          remarks.concat(node.remarks.compact.map do |remark|
             format_remark(node, remark)
           end)
         end

--- a/lib/expressir/express/formatter.rb
+++ b/lib/expressir/express/formatter.rb
@@ -1643,8 +1643,6 @@ module Expressir
           ].join("\n")
         else
           # Handle tail remarks
-          
-          if remark.include?("rule scope - rule informal proposition")
           [
             "--\"",
             node.path || node.id,

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -235,17 +235,9 @@ module Expressir
           if parent_node.class.method_defined?(:informal_propositions) && (
             current_path.match(/^IP\d+$/) || path_prefix.match(/^IP\d+$/)
           )
-
-            id = if /^IP\d+$/.match?(current_path)
-                   current_path
-                 else
-                   path_prefix
-                 end
-
+            id = /^IP\d+$/.match?(current_path) ? current_path : path_prefix
             parent_node.informal_propositions ||= []
-            informal_proposition = Model::Declarations::InformalPropositionRule.new(
-              id: id,
-            )
+            informal_proposition = Model::Declarations::InformalPropositionRule.new(id: id)
 
             informal_proposition.parent = parent_node
             parent_node.informal_propositions << informal_proposition

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -236,11 +236,11 @@ module Expressir
             current_path.match(/^IP\d+$/) || path_prefix.match(/^IP\d+$/)
           )
 
-            id = if current_path.match(/^IP\d+$/)
-                 current_path
-               else
-                 path_prefix
-               end
+            id = if /^IP\d+$/.match?(current_path)
+                   current_path
+                 else
+                   path_prefix
+                 end
 
             parent_node.informal_propositions ||= []
             informal_proposition = Model::Declarations::InformalPropositionRule.new(
@@ -253,7 +253,7 @@ module Expressir
             # Reassign the informal proposition id to the remark item
             remark_item.id = id
             remark_item.parent = informal_proposition
-            
+
             informal_proposition.remark_items ||= []
             informal_proposition.remark_items << remark_item
 

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -238,7 +238,6 @@ module Expressir
             id = /^IP\d+$/.match?(current_path) ? current_path : path_prefix
             parent_node.informal_propositions ||= []
             informal_proposition = Model::Declarations::InformalPropositionRule.new(id: id)
-
             informal_proposition.parent = parent_node
             parent_node.informal_propositions << informal_proposition
 
@@ -250,13 +249,12 @@ module Expressir
             informal_proposition.remark_items << remark_item
 
             parent_node.reset_children_by_id
-            remark_item
           else
             parent_node.remark_items ||= []
             parent_node.remark_items << remark_item
             remark_item.parent = parent_node
-            remark_item
           end
+          remark_item
         end
       end
 

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -247,13 +247,12 @@ module Expressir
 
             informal_proposition.remark_items ||= []
             informal_proposition.remark_items << remark_item
-
-            parent_node.reset_children_by_id
           else
             parent_node.remark_items ||= []
             parent_node.remark_items << remark_item
             remark_item.parent = parent_node
           end
+          parent_node.reset_children_by_id
           remark_item
         end
       end

--- a/lib/expressir/express/visitor.rb
+++ b/lib/expressir/express/visitor.rb
@@ -258,7 +258,7 @@ module Expressir
             informal_proposition.remark_items << remark_item
 
             parent_node.reset_children_by_id
-            informal_proposition
+            remark_item
           else
             parent_node.remark_items ||= []
             parent_node.remark_items << remark_item
@@ -324,10 +324,11 @@ module Expressir
               end
             end
           elsif text.match?(/^--IP\d+:/)
-            # Tagged tail remark: --IP1: content
-            remark_target_path = text[2..].strip.force_encoding("UTF-8")
+            # Unquoted tagged tail remark: --IP1: content
+            remark_target_path = text[2..].strip
+            colon_end = text.index(":", 5)
+            remark_text = text[(colon_end + 1)...-2].strip.force_encoding("UTF-8")
             remark_target = find_remark_target(node, remark_target_path)
-            # binding.pry
             if remark_target
               tagged_remark_tokens << [span, remark_target, remark_text]
             end

--- a/lib/expressir/model/declarations/entity.rb
+++ b/lib/expressir/model/declarations/entity.rb
@@ -12,7 +12,7 @@ module Expressir
         attribute :attributes, Attribute, collection: true
         attribute :unique_rules, UniqueRule, collection: true
         attribute :where_rules, WhereRule, collection: true
-        attribute :informal_propositions, RemarkItem, collection: true
+        attribute :informal_propositions, InformalPropositionRule, collection: true
         attribute :_class, :string, default: -> { send(:name) }
 
         key_value do

--- a/lib/expressir/model/declarations/informal_proposition_rule.rb
+++ b/lib/expressir/model/declarations/informal_proposition_rule.rb
@@ -13,7 +13,6 @@ module Expressir
           map "expression", to: :expression
         end
 
-        # @return [Array<Declaration>]
         def children
           [
             *remark_items,

--- a/lib/expressir/model/declarations/informal_proposition_rule.rb
+++ b/lib/expressir/model/declarations/informal_proposition_rule.rb
@@ -22,4 +22,4 @@ module Expressir
       end
     end
   end
-end 
+end

--- a/lib/expressir/model/declarations/informal_proposition_rule.rb
+++ b/lib/expressir/model/declarations/informal_proposition_rule.rb
@@ -1,0 +1,25 @@
+module Expressir
+  module Model
+    module Declarations
+      # Informal proposition rules are used to specify constraints that cannot be formally expressed
+      class InformalPropositionRule < ModelElement
+        include Identifier
+
+        attribute :expression, ModelElement
+        attribute :_class, :string, default: -> { send(:name) }
+
+        key_value do
+          map "_class", to: :_class, render_default: true
+          map "expression", to: :expression
+        end
+
+        # @return [Array<Declaration>]
+        def children
+          [
+            *remark_items,
+          ]
+        end
+      end
+    end
+  end
+end 

--- a/lib/expressir/model/declarations/rule.rb
+++ b/lib/expressir/model/declarations/rule.rb
@@ -16,7 +16,7 @@ module Expressir
         attribute :variables, Variable, collection: true
         attribute :statements, ModelElement, collection: true
         attribute :where_rules, WhereRule, collection: true
-        attribute :informal_propositions, RemarkItem, collection: true
+        attribute :informal_propositions, InformalPropositionRule, collection: true
         attribute :_class, :string, default: -> { send(:name) }
 
         key_value do

--- a/lib/expressir/model/declarations/type.rb
+++ b/lib/expressir/model/declarations/type.rb
@@ -8,7 +8,7 @@ module Expressir
 
         attribute :underlying_type, ModelElement
         attribute :where_rules, WhereRule, collection: true
-        attribute :informal_propositions, RemarkItem, collection: true
+        attribute :informal_propositions, InformalPropositionRule, collection: true
         attribute :_class, :string, default: -> { send(:name) }
 
         key_value do

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -86,7 +86,7 @@ module Expressir
         "Expressir::Model::Statements::Return" => "Expressir::Model::Statements::Return",
         "Expressir::Model::Statements::Skip" => "Expressir::Model::Statements::Skip",
         "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression" => "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression",
-        "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression" => "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression"
+        "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression" => "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression",
       }.freeze
 
       key_value do

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -186,7 +186,15 @@ module Expressir
         path_parts = []
         loop do
           if current_node.class.method_defined?(:id) && !(current_node.is_a? References::SimpleReference)
-            path_parts << current_node.id
+            # Skip adding the ID if this is a RemarkItem that belongs to an InformalPropositionRule
+            # and has the same ID as its parent
+            if current_node.is_a?(Declarations::RemarkItem) && 
+               current_node.parent.is_a?(Declarations::InformalPropositionRule) &&
+               current_node.id == current_node.parent.id
+              # Skip this ID
+            else
+              path_parts << current_node.id
+            end
           end
 
           current_node = current_node.parent

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -188,9 +188,9 @@ module Expressir
           if current_node.class.method_defined?(:id) && !(current_node.is_a? References::SimpleReference)
             # Skip adding the ID if this is a RemarkItem that belongs to an InformalPropositionRule
             # and has the same ID as its parent
-            if current_node.is_a?(Declarations::RemarkItem) && 
-               current_node.parent.is_a?(Declarations::InformalPropositionRule) &&
-               current_node.id == current_node.parent.id
+            if current_node.is_a?(Declarations::RemarkItem) &&
+                current_node.parent.is_a?(Declarations::InformalPropositionRule) &&
+                current_node.id == current_node.parent.id
               # Skip this ID
             else
               path_parts << current_node.id

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -79,6 +79,8 @@ module Expressir
             "Expressir::Model::Declarations::Procedure",
                         "Expressir::Model::Declarations::RemarkItem" =>
             "Expressir::Model::Declarations::RemarkItem",
+                        "Expressir::Model::Declarations::InformalPropositionRule" =>
+            "Expressir::Model::Declarations::InformalPropositionRule",
                         "Expressir::Model::Declarations::Rule" =>
             "Expressir::Model::Declarations::Rule",
                         "Expressir::Model::Declarations::SchemaVersionItem" =>

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -15,153 +15,82 @@ module Expressir
       attribute :source, :string
       attribute :untagged_remarks, :string, collection: true
 
-      # TODO: Add basic mappings that can be inherited by all subclasses
+      POLYMORPHIC_CLASS_MAP = {
+        "Expressir::Model::Cache" => "Expressir::Model::Cache",
+        "Expressir::Model::Repository" => "Expressir::Model::Repository",
+        "Expressir::Model::DataTypes::Aggregate" => "Expressir::Model::DataTypes::Aggregate",
+        "Expressir::Model::DataTypes::Array" => "Expressir::Model::DataTypes::Array",
+        "Expressir::Model::DataTypes::Bag" => "Expressir::Model::DataTypes::Bag",
+        "Expressir::Model::DataTypes::Binary" => "Expressir::Model::DataTypes::Binary",
+        "Expressir::Model::DataTypes::Boolean" => "Expressir::Model::DataTypes::Boolean",
+        "Expressir::Model::DataTypes::EnumerationItem" => "Expressir::Model::DataTypes::EnumerationItem",
+        "Expressir::Model::DataTypes::Enumeration" => "Expressir::Model::DataTypes::Enumeration",
+        "Expressir::Model::DataTypes::GenericEntity" => "Expressir::Model::DataTypes::GenericEntity",
+        "Expressir::Model::DataTypes::Generic" => "Expressir::Model::DataTypes::Generic",
+        "Expressir::Model::DataTypes::Integer" => "Expressir::Model::DataTypes::Integer",
+        "Expressir::Model::DataTypes::List" => "Expressir::Model::DataTypes::List",
+        "Expressir::Model::DataTypes::Logical" => "Expressir::Model::DataTypes::Logical",
+        "Expressir::Model::DataTypes::Number" => "Expressir::Model::DataTypes::Number",
+        "Expressir::Model::DataTypes::Real" => "Expressir::Model::DataTypes::Real",
+        "Expressir::Model::DataTypes::Select" => "Expressir::Model::DataTypes::Select",
+        "Expressir::Model::DataTypes::Set" => "Expressir::Model::DataTypes::Set",
+        "Expressir::Model::DataTypes::String" => "Expressir::Model::DataTypes::String",
+        "Expressir::Model::Declarations::DerivedAttribute" => "Expressir::Model::Declarations::DerivedAttribute",
+        "Expressir::Model::Declarations::Attribute" => "Expressir::Model::Declarations::Attribute",
+        "Expressir::Model::Declarations::Constant" => "Expressir::Model::Declarations::Constant",
+        "Expressir::Model::Declarations::Entity" => "Expressir::Model::Declarations::Entity",
+        "Expressir::Model::Declarations::Function" => "Expressir::Model::Declarations::Function",
+        "Expressir::Model::Declarations::InterfaceItem" => "Expressir::Model::Declarations::InterfaceItem",
+        "Expressir::Model::Declarations::Interface" => "Expressir::Model::Declarations::Interface",
+        "Expressir::Model::Declarations::InterfacedItem" => "Expressir::Model::Declarations::InterfacedItem",
+        "Expressir::Model::Declarations::Parameter" => "Expressir::Model::Declarations::Parameter",
+        "Expressir::Model::Declarations::Procedure" => "Expressir::Model::Declarations::Procedure",
+        "Expressir::Model::Declarations::RemarkItem" => "Expressir::Model::Declarations::RemarkItem",
+        "Expressir::Model::Declarations::InformalPropositionRule" => "Expressir::Model::Declarations::InformalPropositionRule",
+        "Expressir::Model::Declarations::Rule" => "Expressir::Model::Declarations::Rule",
+        "Expressir::Model::Declarations::SchemaVersionItem" => "Expressir::Model::Declarations::SchemaVersionItem",
+        "Expressir::Model::Declarations::SchemaVersion" => "Expressir::Model::Declarations::SchemaVersion",
+        "Expressir::Model::Declarations::Schema" => "Expressir::Model::Declarations::Schema",
+        "Expressir::Model::Declarations::SubtypeConstraint" => "Expressir::Model::Declarations::SubtypeConstraint",
+        "Expressir::Model::Declarations::Type" => "Expressir::Model::Declarations::Type",
+        "Expressir::Model::Declarations::UniqueRule" => "Expressir::Model::Declarations::UniqueRule",
+        "Expressir::Model::Declarations::Variable" => "Expressir::Model::Declarations::Variable",
+        "Expressir::Model::Declarations::WhereRule" => "Expressir::Model::Declarations::WhereRule",
+        "Expressir::Model::Expressions::AggregateInitializerItem" => "Expressir::Model::Expressions::AggregateInitializerItem",
+        "Expressir::Model::Expressions::AggregateInitializer" => "Expressir::Model::Expressions::AggregateInitializer",
+        "Expressir::Model::Expressions::BinaryExpression" => "Expressir::Model::Expressions::BinaryExpression",
+        "Expressir::Model::Expressions::EntityConstructor" => "Expressir::Model::Expressions::EntityConstructor",
+        "Expressir::Model::Expressions::FunctionCall" => "Expressir::Model::Expressions::FunctionCall",
+        "Expressir::Model::Expressions::Interval" => "Expressir::Model::Expressions::Interval",
+        "Expressir::Model::Expressions::QueryExpression" => "Expressir::Model::Expressions::QueryExpression",
+        "Expressir::Model::Expressions::UnaryExpression" => "Expressir::Model::Expressions::UnaryExpression",
+        "Expressir::Model::Literals::Binary" => "Expressir::Model::Literals::Binary",
+        "Expressir::Model::Literals::Integer" => "Expressir::Model::Literals::Integer",
+        "Expressir::Model::Literals::Logical" => "Expressir::Model::Literals::Logical",
+        "Expressir::Model::Literals::Real" => "Expressir::Model::Literals::Real",
+        "Expressir::Model::Literals::String" => "Expressir::Model::Literals::String",
+        "Expressir::Model::References::AttributeReference" => "Expressir::Model::References::AttributeReference",
+        "Expressir::Model::References::GroupReference" => "Expressir::Model::References::GroupReference",
+        "Expressir::Model::References::IndexReference" => "Expressir::Model::References::IndexReference",
+        "Expressir::Model::References::SimpleReference" => "Expressir::Model::References::SimpleReference",
+        "Expressir::Model::Statements::Alias" => "Expressir::Model::Statements::Alias",
+        "Expressir::Model::Statements::Assignment" => "Expressir::Model::Statements::Assignment",
+        "Expressir::Model::Statements::CaseAction" => "Expressir::Model::Statements::CaseAction",
+        "Expressir::Model::Statements::Case" => "Expressir::Model::Statements::Case",
+        "Expressir::Model::Statements::Compound" => "Expressir::Model::Statements::Compound",
+        "Expressir::Model::Statements::Escape" => "Expressir::Model::Statements::Escape",
+        "Expressir::Model::Statements::If" => "Expressir::Model::Statements::If",
+        "Expressir::Model::Statements::Null" => "Expressir::Model::Statements::Null",
+        "Expressir::Model::Statements::ProcedureCall" => "Expressir::Model::Statements::ProcedureCall",
+        "Expressir::Model::Statements::Repeat" => "Expressir::Model::Statements::Repeat",
+        "Expressir::Model::Statements::Return" => "Expressir::Model::Statements::Return",
+        "Expressir::Model::Statements::Skip" => "Expressir::Model::Statements::Skip",
+        "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression" => "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression",
+        "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression" => "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression"
+      }.freeze
+
       key_value do
-        map "_class", to: :_class, render_default: true,
-                      polymorphic_map: {
-                        "Expressir::Model::Cache" =>
-                        "Expressir::Model::Cache",
-                        "Expressir::Model::Repository" =>
-            "Expressir::Model::Repository",
-                        "Expressir::Model::DataTypes::Aggregate" =>
-            "Expressir::Model::DataTypes::Aggregate",
-                        "Expressir::Model::DataTypes::Array" =>
-            "Expressir::Model::DataTypes::Array",
-                        "Expressir::Model::DataTypes::Bag" =>
-            "Expressir::Model::DataTypes::Bag",
-                        "Expressir::Model::DataTypes::Binary" =>
-            "Expressir::Model::DataTypes::Binary",
-                        "Expressir::Model::DataTypes::Boolean" =>
-            "Expressir::Model::DataTypes::Boolean",
-                        "Expressir::Model::DataTypes::EnumerationItem" =>
-            "Expressir::Model::DataTypes::EnumerationItem",
-                        "Expressir::Model::DataTypes::Enumeration" =>
-            "Expressir::Model::DataTypes::Enumeration",
-                        "Expressir::Model::DataTypes::GenericEntity" =>
-            "Expressir::Model::DataTypes::GenericEntity",
-                        "Expressir::Model::DataTypes::Generic" =>
-            "Expressir::Model::DataTypes::Generic",
-                        "Expressir::Model::DataTypes::Integer" =>
-            "Expressir::Model::DataTypes::Integer",
-                        "Expressir::Model::DataTypes::List" =>
-            "Expressir::Model::DataTypes::List",
-                        "Expressir::Model::DataTypes::Logical" =>
-            "Expressir::Model::DataTypes::Logical",
-                        "Expressir::Model::DataTypes::Number" =>
-            "Expressir::Model::DataTypes::Number",
-                        "Expressir::Model::DataTypes::Real" =>
-            "Expressir::Model::DataTypes::Real",
-                        "Expressir::Model::DataTypes::Select" =>
-            "Expressir::Model::DataTypes::Select",
-                        "Expressir::Model::DataTypes::Set" =>
-            "Expressir::Model::DataTypes::Set",
-                        "Expressir::Model::DataTypes::String" =>
-            "Expressir::Model::DataTypes::String",
-                        "Expressir::Model::Declarations::DerivedAttribute" =>
-            "Expressir::Model::Declarations::DerivedAttribute",
-                        "Expressir::Model::Declarations::Attribute" =>
-            "Expressir::Model::Declarations::Attribute",
-                        "Expressir::Model::Declarations::Constant" =>
-            "Expressir::Model::Declarations::Constant",
-                        "Expressir::Model::Declarations::Entity" =>
-            "Expressir::Model::Declarations::Entity",
-                        "Expressir::Model::Declarations::Function" =>
-            "Expressir::Model::Declarations::Function",
-                        "Expressir::Model::Declarations::InterfaceItem" =>
-            "Expressir::Model::Declarations::InterfaceItem",
-                        "Expressir::Model::Declarations::Interface" =>
-            "Expressir::Model::Declarations::Interface",
-                        "Expressir::Model::Declarations::InterfacedItem" =>
-            "Expressir::Model::Declarations::InterfacedItem",
-                        "Expressir::Model::Declarations::Parameter" =>
-            "Expressir::Model::Declarations::Parameter",
-                        "Expressir::Model::Declarations::Procedure" =>
-            "Expressir::Model::Declarations::Procedure",
-                        "Expressir::Model::Declarations::RemarkItem" =>
-            "Expressir::Model::Declarations::RemarkItem",
-                        "Expressir::Model::Declarations::InformalPropositionRule" =>
-            "Expressir::Model::Declarations::InformalPropositionRule",
-                        "Expressir::Model::Declarations::Rule" =>
-            "Expressir::Model::Declarations::Rule",
-                        "Expressir::Model::Declarations::SchemaVersionItem" =>
-            "Expressir::Model::Declarations::SchemaVersionItem",
-                        "Expressir::Model::Declarations::SchemaVersion" =>
-            "Expressir::Model::Declarations::SchemaVersion",
-                        "Expressir::Model::Declarations::Schema" =>
-            "Expressir::Model::Declarations::Schema",
-                        "Expressir::Model::Declarations::SubtypeConstraint" =>
-            "Expressir::Model::Declarations::SubtypeConstraint",
-                        "Expressir::Model::Declarations::Type" =>
-            "Expressir::Model::Declarations::Type",
-                        "Expressir::Model::Declarations::UniqueRule" =>
-            "Expressir::Model::Declarations::UniqueRule",
-                        "Expressir::Model::Declarations::Variable" =>
-            "Expressir::Model::Declarations::Variable",
-                        "Expressir::Model::Declarations::WhereRule" =>
-            "Expressir::Model::Declarations::WhereRule",
-                        "Expressir::Model::Expressions::AggregateInitializerItem" =>
-            "Expressir::Model::Expressions::AggregateInitializerItem",
-                        "Expressir::Model::Expressions::AggregateInitializer" =>
-            "Expressir::Model::Expressions::AggregateInitializer",
-                        "Expressir::Model::Expressions::BinaryExpression" =>
-            "Expressir::Model::Expressions::BinaryExpression",
-                        "Expressir::Model::Expressions::EntityConstructor" =>
-            "Expressir::Model::Expressions::EntityConstructor",
-                        "Expressir::Model::Expressions::FunctionCall" =>
-            "Expressir::Model::Expressions::FunctionCall",
-                        "Expressir::Model::Expressions::Interval" =>
-            "Expressir::Model::Expressions::Interval",
-                        "Expressir::Model::Expressions::QueryExpression" =>
-            "Expressir::Model::Expressions::QueryExpression",
-                        "Expressir::Model::Expressions::UnaryExpression" =>
-            "Expressir::Model::Expressions::UnaryExpression",
-                        "Expressir::Model::Literals::Binary" =>
-            "Expressir::Model::Literals::Binary",
-                        "Expressir::Model::Literals::Integer" =>
-            "Expressir::Model::Literals::Integer",
-                        "Expressir::Model::Literals::Logical" =>
-            "Expressir::Model::Literals::Logical",
-                        "Expressir::Model::Literals::Real" =>
-            "Expressir::Model::Literals::Real",
-                        "Expressir::Model::Literals::String" =>
-            "Expressir::Model::Literals::String",
-                        "Expressir::Model::References::AttributeReference" =>
-            "Expressir::Model::References::AttributeReference",
-                        "Expressir::Model::References::GroupReference" =>
-            "Expressir::Model::References::GroupReference",
-                        "Expressir::Model::References::IndexReference" =>
-            "Expressir::Model::References::IndexReference",
-                        "Expressir::Model::References::SimpleReference" =>
-            "Expressir::Model::References::SimpleReference",
-                        "Expressir::Model::Statements::Alias" =>
-            "Expressir::Model::Statements::Alias",
-                        "Expressir::Model::Statements::Assignment" =>
-            "Expressir::Model::Statements::Assignment",
-                        "Expressir::Model::Statements::CaseAction" =>
-            "Expressir::Model::Statements::CaseAction",
-                        "Expressir::Model::Statements::Case" =>
-            "Expressir::Model::Statements::Case",
-                        "Expressir::Model::Statements::Compound" =>
-            "Expressir::Model::Statements::Compound",
-                        "Expressir::Model::Statements::Escape" =>
-            "Expressir::Model::Statements::Escape",
-                        "Expressir::Model::Statements::If" =>
-            "Expressir::Model::Statements::If",
-                        "Expressir::Model::Statements::Null" =>
-            "Expressir::Model::Statements::Null",
-                        "Expressir::Model::Statements::ProcedureCall" =>
-            "Expressir::Model::Statements::ProcedureCall",
-                        "Expressir::Model::Statements::Repeat" =>
-            "Expressir::Model::Statements::Repeat",
-                        "Expressir::Model::Statements::Return" =>
-            "Expressir::Model::Statements::Return",
-                        "Expressir::Model::Statements::Skip" =>
-            "Expressir::Model::Statements::Skip",
-                        "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression" =>
-            "Expressir::Model::SupertypeExpressions::BinarySupertypeExpression",
-                        "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression" =>
-            "Expressir::Model::SupertypeExpressions::OneofSupertypeExpression",
-                      }
+        map "_class", to: :_class, render_default: true, polymorphic_map: POLYMORPHIC_CLASS_MAP
       end
 
       def source

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -114,16 +114,13 @@ module Expressir
         current_node = self
         path_parts = []
         loop do
-          if current_node.class.method_defined?(:id) && !(current_node.is_a? References::SimpleReference)
-            # Skip adding the ID if this is a RemarkItem that belongs to an InformalPropositionRule
-            # and has the same ID as its parent
-            if current_node.is_a?(Declarations::RemarkItem) &&
-                current_node.parent.is_a?(Declarations::InformalPropositionRule) &&
-                current_node.id == current_node.parent.id
-              # Skip this ID
-            else
-              path_parts << current_node.id
-            end
+          # Skip adding the id if this is a RemarkItem that belongs to an InformalPropositionRule
+          # and has the same id as its parent
+          if !(current_node.is_a? References::SimpleReference) && current_node.class.method_defined?(:id) &&
+              !(is_a?(Declarations::RemarkItem) &&
+                parent.is_a?(Declarations::InformalPropositionRule) &&
+                id == parent.id)
+            path_parts << current_node.id
           end
 
           current_node = current_node.parent

--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Expressir" do
       expect(Expressir::VERSION).not_to be nil
     end
 
-    it "displays the current verison" do |example|
+    it "displays the current version" do |example|
       print "\n[#{example.description}] "
       command = %w(version)
       output = capture_stdout { Expressir::Cli.start(command) }

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -236,12 +236,10 @@ RSpec.describe Expressir::Express::Parser do
         root_path: Expressir.root_path,
       )
       entity = repo.schemas.first.entities[2]
-      require "pry"
-      binding.pry
       informal_proposition = entity.informal_propositions.first
       expect(informal_proposition.id).to eq("IP1")
       expect(informal_proposition.class).to eq(Expressir::Model::Declarations::InformalPropositionRule)
-      expect(informal_proposition.remark_items.first.remarks).to eq(["country_population > 0"])
+      expect(informal_proposition.remark_items.first.remarks).to eq(["This is informal proposition"])
     end
   end
 

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Expressir::Express::Parser do
       expect(result).to eq(expected_result)
     end
 
-    it "parses a file (mathematical_functions_schema.exp) with remark_items" do |example|
+    xit "parses a file (mathematical_functions_schema.exp) with remark_items" do |example|
       print "\n[#{example.description}] "
       exp_file = Expressir.root_path.join(
         "spec", "syntax", "mathematical_functions_schema",

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Expressir::Express::Parser do
       expect(result).to eq(expected_result)
     end
 
-    xit "parses a file (mathematical_functions_schema.exp) with remark_items" do |example|
+    it "parses a file (mathematical_functions_schema.exp) with remark_items" do |example|
       print "\n[#{example.description}] "
       exp_file = Expressir.root_path.join(
         "spec", "syntax", "mathematical_functions_schema",

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Expressir::Express::Parser do
         root_path: Expressir.root_path,
       )
       result = repo.to_yaml
-      File.write(yaml_file, result)
+      # File.write(yaml_file, result)
       expected_result = File.read(yaml_file)
       expect(result).to eq(expected_result)
     end

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Expressir::Express::Parser do
         root_path: Expressir.root_path,
       )
       result = repo.to_yaml
-      # File.write(yaml_file, result)
+      File.write(yaml_file, result)
       expected_result = File.read(yaml_file)
       expect(result).to eq(expected_result)
     end
@@ -226,6 +226,22 @@ RSpec.describe Expressir::Express::Parser do
 
       entity = repo.schemas.first.entities[4]
       expect(entity.attributes.map(&:id)).to include("country_population")
+    end
+
+    it "parses a file and assigns informal propositions (geometry_schema.exp)" do |_example|
+      exp_file = Expressir.root_path.join("spec", "syntax", "geometry_schema.exp")
+
+      repo = Expressir::Express::Parser.from_file(
+        exp_file,
+        root_path: Expressir.root_path,
+      )
+      entity = repo.schemas.first.entities[2]
+      require 'pry'
+      binding.pry
+      informal_proposition = entity.informal_propositions.first
+      expect(informal_proposition.id).to eq("IP1")
+      expect(informal_proposition.class).to eq(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(informal_proposition.remark_items.first.remarks).to eq(["country_population > 0"])
     end
   end
 

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Expressir::Express::Parser do
         root_path: Expressir.root_path,
       )
       entity = repo.schemas.first.entities[2]
-      require 'pry'
+      require "pry"
       binding.pry
       informal_proposition = entity.informal_propositions.first
       expect(informal_proposition.id).to eq("IP1")

--- a/spec/expressir/model/declarations/entity_spec.rb
+++ b/spec/expressir/model/declarations/entity_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Expressir::Model::Declarations::Entity do
     end
     let(:informal_propositions) do
       [
-        Expressir::Model::Declarations::RemarkItem.new(id: "IP1", remarks: ["First proposition"]),
+        Expressir::Model::Declarations::InformalPropositionRule.new(id: "IP1", remarks: ["First proposition"]),
       ]
     end
 
@@ -300,7 +300,7 @@ RSpec.describe Expressir::Model::Declarations::Entity do
           Expressir::Model::Declarations::WhereRule.new(id: "WR1"),
         ],
         informal_propositions: [
-          Expressir::Model::Declarations::RemarkItem.new(id: "IP1"),
+          Expressir::Model::Declarations::InformalPropositionRule.new(id: "IP1"),
         ],
         remark_items: [
           Expressir::Model::Declarations::RemarkItem.new(id: "remark1"),

--- a/spec/expressir/model/model_element_spec.rb
+++ b/spec/expressir/model/model_element_spec.rb
@@ -155,8 +155,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(repo.find("remark_schema.remark_type")).to be_instance_of(Expressir::Model::Declarations::Type)
       expect(repo.find("remark_schema.remark_type.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(repo.find("remark_schema.remark_type.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(repo.find("remark_schema.remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(repo.find("remark_schema.remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(repo.find("remark_schema.remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(repo.find("remark_schema.remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(repo.find("remark_schema.remark_enumeration_item")).to be_instance_of(Expressir::Model::DataTypes::EnumerationItem)
       expect(repo.find("remark_schema.remark_entity")).to be_instance_of(Expressir::Model::Declarations::Entity)
       expect(repo.find("remark_schema.remark_entity.remark_attribute")).to be_instance_of(Expressir::Model::Declarations::Attribute)
@@ -165,8 +165,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(repo.find("remark_schema.remark_entity.UR1")).to be_instance_of(Expressir::Model::Declarations::UniqueRule)
       expect(repo.find("remark_schema.remark_entity.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(repo.find("remark_schema.remark_entity.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(repo.find("remark_schema.remark_entity.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(repo.find("remark_schema.remark_entity.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(repo.find("remark_schema.remark_entity.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(repo.find("remark_schema.remark_entity.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(repo.find("remark_schema.remark_subtype_constraint")).to be_instance_of(Expressir::Model::Declarations::SubtypeConstraint)
       expect(repo.find("remark_schema.remark_function")).to be_instance_of(Expressir::Model::Declarations::Function)
       expect(repo.find("remark_schema.remark_function.remark_parameter")).to be_instance_of(Expressir::Model::Declarations::Parameter)
@@ -187,8 +187,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(repo.find("remark_schema.remark_rule.remark_variable")).to be_instance_of(Expressir::Model::Declarations::Variable)
       expect(repo.find("remark_schema.remark_rule.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(repo.find("remark_schema.remark_rule.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(repo.find("remark_schema.remark_rule.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(repo.find("remark_schema.remark_rule.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(repo.find("remark_schema.remark_rule.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(repo.find("remark_schema.remark_rule.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(repo.find("remark_schema.remark_item")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
 
       # schema scope
@@ -197,8 +197,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(schema.find("remark_type")).to be_instance_of(Expressir::Model::Declarations::Type)
       expect(schema.find("remark_type.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(schema.find("remark_type.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(schema.find("remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(schema.find("remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(schema.find("remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(schema.find("remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(schema.find("remark_enumeration_item")).to be_instance_of(Expressir::Model::DataTypes::EnumerationItem)
       expect(schema.find("remark_entity")).to be_instance_of(Expressir::Model::Declarations::Entity)
       expect(schema.find("remark_entity.remark_attribute")).to be_instance_of(Expressir::Model::Declarations::Attribute)
@@ -207,8 +207,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(schema.find("remark_entity.UR1")).to be_instance_of(Expressir::Model::Declarations::UniqueRule)
       expect(schema.find("remark_entity.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(schema.find("remark_entity.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(schema.find("remark_entity.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(schema.find("remark_entity.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(schema.find("remark_entity.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(schema.find("remark_entity.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(schema.find("remark_subtype_constraint")).to be_instance_of(Expressir::Model::Declarations::SubtypeConstraint)
       expect(schema.find("remark_function")).to be_instance_of(Expressir::Model::Declarations::Function)
       expect(schema.find("remark_function.remark_parameter")).to be_instance_of(Expressir::Model::Declarations::Parameter)
@@ -229,16 +229,16 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(schema.find("remark_rule.remark_variable")).to be_instance_of(Expressir::Model::Declarations::Variable)
       expect(schema.find("remark_rule.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(schema.find("remark_rule.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(schema.find("remark_rule.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(schema.find("remark_rule.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(schema.find("remark_rule.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(schema.find("remark_rule.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
       expect(schema.find("remark_item")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
 
       # type scope
       type = schema.types.first
       expect(type.find("WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(type.find("wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(type.find("IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(type.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(type.find("IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(type.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
 
       # entity scope
       entity = schema.entities.first
@@ -248,8 +248,8 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(entity.find("UR1")).to be_instance_of(Expressir::Model::Declarations::UniqueRule)
       expect(entity.find("WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(entity.find("wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(entity.find("IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(entity.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(entity.find("IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(entity.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
 
       # function scope
       function = schema.functions.first
@@ -275,15 +275,15 @@ RSpec.describe Expressir::Model::ModelElement do
       expect(rule.find("remark_variable")).to be_instance_of(Expressir::Model::Declarations::Variable)
       expect(rule.find("WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(rule.find("wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(rule.find("IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(rule.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(rule.find("IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(rule.find("ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
 
       # retry search in parent scope
       expect(entity.find("remark_type")).to be_instance_of(Expressir::Model::Declarations::Type)
       expect(entity.find("remark_type.WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
       expect(entity.find("remark_type.wr:WR1")).to be_instance_of(Expressir::Model::Declarations::WhereRule)
-      expect(entity.find("remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
-      expect(entity.find("remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::RemarkItem)
+      expect(entity.find("remark_type.IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
+      expect(entity.find("remark_type.ip:IP1")).to be_instance_of(Expressir::Model::Declarations::InformalPropositionRule)
     end
   end
 

--- a/spec/syntax/geometry_schema.exp
+++ b/spec/syntax/geometry_schema.exp
@@ -1,0 +1,80 @@
+SCHEMA geometry_schema '{iso standard 10303 part(42) version(13) object(1) geometry-schema(1)}';
+
+ENTITY point
+  SUPERTYPE OF (ONEOF (cartesian_point,
+                       degenerate_pcurve))
+  SUBTYPE OF (geometric_representation_item);
+END_ENTITY;
+
+ENTITY cartesian_point
+  SUPERTYPE OF (spherical_point)
+  SUBTYPE OF (point);
+  coordinates : LIST[1:3] OF length_measure;
+END_ENTITY;
+
+ENTITY spherical_point
+  SUBTYPE OF (cartesian_point);
+  r : length_measure;
+  theta : plane_angle_measure;
+  phi : plane_angle_measure;
+DERIVE
+  SELF\cartesian_point.coordinates : LIST[3:3] OF length_measure := [r*sin(theta)*cos(phi), r*sin(theta)*sin(phi), r*cos(theta)];
+WHERE
+  WR1: r >= 0.0;
+  --IP1: This is informal proposition 1
+  --IP2: This is informal proposition 2
+END_ENTITY;
+
+(*"geometry_schema.spherical_point"
+A **spherical_point** is a type of <<express:geometry_schema.cartesian_point,cartesian_point>> which uses a spherical polar coordinate system, centred at the origin of the corresponding Cartesian coordinate system, to define its location.
+*)
+
+(*"geometry_schema.spherical_point.r"
+the distance from the point to the z axis;
+*)
+
+(*"geometry_schema.spherical_point.theta"
+the angle stem:[theta] between the z axis and the line joining the origin to the point;
+*)
+
+(*"geometry_schema.spherical_point.phi"
+the angle stem:[phi] measured from the x axis to the projection onto the xy plane of the line from the origin to the point.
+*)
+
+(*"geometry_schema.spherical_point.coordinates"
+the rectangular cartesian coordinates of this point;
+*)
+
+(*"geometry_schema.spherical_point.coordinates.__figure"
+[[figure-geometry_schema-Geomfig2]]
+.Spherical point attributes
+====
+image::Geomfig2.gif[]
+====
+*)
+
+(*"geometry_schema.spherical_point.coordinates.__note"
+See <<figure-geometry_schema-Geomfig2>> for an illustration of the attributes.
+*)
+
+(*"geometry_schema.spherical_point.wr:WR1"
+The radius **r** shall be greater than, or equal to zero.
+*)
+
+(*"geometry_schema.spherical_point.wr:WR1.__note"
+This is a note for WR1.
+*)
+
+(*"geometry_schema.spherical_point.wr:IP1"
+The value of **theta** shall lie in the range stem:[0 le theta le 180 "P{degree}"].
+*)
+
+(*"geometry_schema.spherical_point.wr:IP2"
+The value of **phi** shall lie in the range stem:[0 le phi < 360 "P{degree}"].
+*)
+
+(*"geometry_schema.spherical_point.wr:IP2.__note"
+This is a note for IP2.
+*)
+
+END_SCHEMA;  -- geometry_schema

--- a/spec/syntax/remark_formatted.exp
+++ b/spec/syntax/remark_formatted.exp
@@ -120,12 +120,12 @@ several physical lines.
 --"remark_schema.remark_type.WR1" schema scope - type where, with prefix
 --"remark_schema.remark_type.WR1" universal scope - type where
 --"remark_schema.remark_type.WR1" universal scope - type where, with prefix
---"remark_schema.remark_type.IP1" type scope - type informal proposition
 --"remark_schema.remark_type.IP1" type scope - type informal proposition, with prefix
 --"remark_schema.remark_type.IP1" schema scope - type informal proposition
 --"remark_schema.remark_type.IP1" schema scope - type informal proposition, with prefix
 --"remark_schema.remark_type.IP1" universal scope - type informal proposition
 --"remark_schema.remark_type.IP1" universal scope - type informal proposition, with prefix
+--"remark_schema.remark_type.IP1" type scope - type informal proposition
 --"remark_schema.remark_entity" schema scope - entity
 --"remark_schema.remark_entity" universal scope - entity
 --"remark_schema.remark_entity.remark_attribute" entity scope - entity attribute
@@ -147,12 +147,12 @@ several physical lines.
 --"remark_schema.remark_entity.WR1" universal scope - entity where
 --"remark_schema.remark_entity.WR1" universal scope - entity where, with prefix
 --"remark_schema.remark_entity.WR1.unusual_placement" placed inside WHERE clauses (or other enumerable context)
---"remark_schema.remark_entity.IP1" entity scope - entity informal proposition
 --"remark_schema.remark_entity.IP1" entity scope - entity informal proposition, with prefix
 --"remark_schema.remark_entity.IP1" schema scope - entity informal proposition
 --"remark_schema.remark_entity.IP1" schema scope - entity informal proposition, with prefix
 --"remark_schema.remark_entity.IP1" universal scope - entity informal proposition
 --"remark_schema.remark_entity.IP1" universal scope - entity informal proposition, with prefix
+--"remark_schema.remark_entity.IP1" entity scope - entity informal proposition
 --"remark_schema.remark_subtype_constraint" schema scope - subtype constraint
 --"remark_schema.remark_subtype_constraint" universal scope - subtype constraint
 --"remark_schema.remark_function" schema scope - function
@@ -198,12 +198,12 @@ several physical lines.
 --"remark_schema.remark_rule.WR1" schema scope - rule where, with prefix
 --"remark_schema.remark_rule.WR1" universal scope - rule where
 --"remark_schema.remark_rule.WR1" universal scope - rule where, with prefix
---"remark_schema.remark_rule.IP1" rule scope - rule informal proposition
 --"remark_schema.remark_rule.IP1" rule scope - rule informal proposition, with prefix
 --"remark_schema.remark_rule.IP1" schema scope - rule informal proposition
 --"remark_schema.remark_rule.IP1" schema scope - rule informal proposition, with prefix
 --"remark_schema.remark_rule.IP1" universal scope - rule informal proposition
 --"remark_schema.remark_rule.IP1" universal scope - rule informal proposition, with prefix
+--"remark_schema.remark_rule.IP1" rule scope - rule informal proposition
 --"remark_schema.remark_procedure" schema scope - procedure
 --"remark_schema.remark_procedure" universal scope - procedure
 --"remark_schema.remark_procedure.remark_parameter" procedure scope - procedure parameter

--- a/spec/syntax/remark_parser.yaml
+++ b/spec/syntax/remark_parser.yaml
@@ -60,15 +60,14 @@ schemas:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
     informal_propositions:
-    - _class: Expressir::Model::Declarations::RemarkItem
-      id: IP1
+    - id: IP1
       remarks:
-      - type scope - type informal proposition
       - type scope - type informal proposition, with prefix
       - schema scope - type informal proposition
       - schema scope - type informal proposition, with prefix
       - universal scope - type informal proposition
       - universal scope - type informal proposition, with prefix
+      _class: Expressir::Model::Declarations::InformalPropositionRule
   entities:
   - id: remark_entity
     remarks:
@@ -142,15 +141,14 @@ schemas:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
     informal_propositions:
-    - _class: Expressir::Model::Declarations::RemarkItem
-      id: IP1
+    - id: IP1
       remarks:
-      - entity scope - entity informal proposition
       - entity scope - entity informal proposition, with prefix
       - schema scope - entity informal proposition
       - schema scope - entity informal proposition, with prefix
       - universal scope - entity informal proposition
       - universal scope - entity informal proposition, with prefix
+      _class: Expressir::Model::Declarations::InformalPropositionRule
   subtype_constraints:
   - id: remark_subtype_constraint
     remarks:
@@ -367,15 +365,14 @@ schemas:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
     informal_propositions:
-    - _class: Expressir::Model::Declarations::RemarkItem
-      id: IP1
+    - id: IP1
       remarks:
-      - rule scope - rule informal proposition
       - rule scope - rule informal proposition, with prefix
       - schema scope - rule informal proposition
       - schema scope - rule informal proposition, with prefix
       - universal scope - rule informal proposition
       - universal scope - rule informal proposition, with prefix
+      _class: Expressir::Model::Declarations::InformalPropositionRule
   procedures:
   - id: remark_procedure
     remarks:

--- a/spec/syntax/remark_parser.yaml
+++ b/spec/syntax/remark_parser.yaml
@@ -16,6 +16,9 @@ schemas:
     id: remark_item
     remarks:
     - schema scope - schema remark item
+  - _class: Expressir::Model::Declarations::RemarkItem
+    id: remark_item
+    remarks:
     - universal scope - schema remark item
   _class: Expressir::Model::Declarations::Schema
   file: spec/syntax/remark.exp
@@ -67,6 +70,11 @@ schemas:
       - schema scope - type informal proposition, with prefix
       - universal scope - type informal proposition
       - universal scope - type informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - type scope - type informal proposition
       _class: Expressir::Model::Declarations::InformalPropositionRule
   entities:
   - id: remark_entity
@@ -148,6 +156,11 @@ schemas:
       - schema scope - entity informal proposition, with prefix
       - universal scope - entity informal proposition
       - universal scope - entity informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - entity scope - entity informal proposition
       _class: Expressir::Model::Declarations::InformalPropositionRule
   subtype_constraints:
   - id: remark_subtype_constraint
@@ -372,6 +385,11 @@ schemas:
       - schema scope - rule informal proposition, with prefix
       - universal scope - rule informal proposition
       - universal scope - rule informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - rule scope - rule informal proposition
       _class: Expressir::Model::Declarations::InformalPropositionRule
   procedures:
   - id: remark_procedure

--- a/spec/syntax/remark_parser.yaml
+++ b/spec/syntax/remark_parser.yaml
@@ -16,9 +16,6 @@ schemas:
     id: remark_item
     remarks:
     - schema scope - schema remark item
-  - _class: Expressir::Model::Declarations::RemarkItem
-    id: remark_item
-    remarks:
     - universal scope - schema remark item
   _class: Expressir::Model::Declarations::Schema
   file: spec/syntax/remark.exp


### PR DESCRIPTION
This commit adds the `InformalPropositionRule` class in a similar manner to the `WhereRule` class.
As described in #50 and #78, informal propositions are embedded within remarks both embedded and tail remarks.

However, as further described in #248 there is the need for reaching to child remarks from within an informal proposition, and this is taken care of by this commit as well.

An exception in the way paths are constructed was made in the `ModelElement` class `path` method to be able to format informal propositions and remark_items together whenever the latter is a child of the first one.