### PR TITLE
perf: make schema.formatted lazy to avoid eager tree walk

### DIFF
--- a/lib/expressir/commands/changes_import_eengine.rb
+++ b/lib/expressir/commands/changes_import_eengine.rb
@@ -115,26 +115,6 @@ module Expressir
           end
         end
 
-        def extract_description(compare_report)
-          parts = []
-
-          [compare_report.modifications, compare_report.additions,
-           compare_report.deletions].each do |section|
-            next unless section&.modified_objects
-
-            section.modified_objects.each do |obj|
-              next unless obj.description
-
-              description_text = normalize_description(obj.description)
-              next if description_text.strip.empty?
-
-              parts << convert_html_to_asciidoc(description_text.strip)
-            end
-          end
-
-          parts.empty? ? nil : parts.join("\n\n")
-        end
-
         def normalize_description(description)
           # Handle both String and Array (when XML has nested elements)
           case description

--- a/lib/expressir/express/builder.rb
+++ b/lib/expressir/express/builder.rb
@@ -340,14 +340,6 @@ module Expressir
           end
         end
 
-        def to_snake_case(name)
-          cached_snake_case(name)
-        end
-
-        def convert_keys_to_snake_case(obj)
-          fast_convert_keys(obj)
-        end
-
         def extract_source_info(data)
           return nil unless data
           return nil unless @source

--- a/lib/expressir/express/parser.rb
+++ b/lib/expressir/express/parser.rb
@@ -728,7 +728,6 @@ module Expressir
           @exp_file.schemas.each do |schema|
             schema.file = schema_file
             schema.file_basename = File.basename(schema_file, ".exp")
-            schema.formatted = schema.to_s(no_remarks: true)
           end
 
           unless skip_references
@@ -820,7 +819,6 @@ root_path: nil, use_native: nil)
         exp_file.schemas.each do |schema|
           schema.file = nil
           schema.file_basename = nil
-          schema.formatted = schema.to_s(no_remarks: true)
         end
 
         unless skip_references
@@ -855,7 +853,6 @@ include_source: nil)
         exp_file.schemas.each do |schema|
           schema.file = nil
           schema.file_basename = nil
-          schema.formatted = schema.to_s(no_remarks: true)
         end
 
         unless skip_references
@@ -903,7 +900,6 @@ include_source: nil)
         exp_file.schemas.each do |schema|
           schema.file = nil
           schema.file_basename = nil
-          schema.formatted = schema.to_s(no_remarks: true)
         end
 
         unless skip_references

--- a/lib/expressir/model/declarations/schema.rb
+++ b/lib/expressir/model/declarations/schema.rb
@@ -19,7 +19,6 @@ module Expressir
         attribute :procedures, Procedure, collection: true
         attribute :_class, :string, default: -> { self.class.name }
         attribute :selected, :boolean, default: false
-        attribute :formatted, :string
         attribute :file_basename, :string
 
         key_value do
@@ -64,6 +63,10 @@ module Expressir
 
         def full_source
           Expressir::Express::Formatter.format(self)
+        end
+
+        def formatted
+          @formatted ||= to_s(no_remarks: true)
         end
 
         def source

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -203,14 +203,6 @@ module Expressir
         self.untagged_remarks << remark_info
       end
 
-      # Get all remarks as RemarkInfo objects
-      # @return [Array<RemarkInfo>] Array of RemarkInfo objects
-      def remark_infos
-        return [] if untagged_remarks.nil?
-
-        untagged_remarks.grep(RemarkInfo)
-      end
-
       private
 
       # @return [nil]

--- a/lib/expressir/transformer.rb
+++ b/lib/expressir/transformer.rb
@@ -1,7 +1,0 @@
-module Expressir
-  module Express
-    module Transformer
-      autoload :RemarkHandling, "#{__dir__}/express/transformer/remark_handling"
-    end
-  end
-end


### PR DESCRIPTION
## Summary

- Changed `formatted` from eager attribute to lazy method in Schema class
- Removed 4 eager `schema.formatted = schema.to_s(no_remarks: true)` assignments from parser.rb
- Avoids full tree walk per schema parse — only computed when accessed

## Dead Code Removal

- Removed dead `to_snake_case` and `convert_keys_to_snake_case` from builder.rb
- Removed dead `remark_infos` from model_element.rb
- Removed dead `extract_description` from changes_import_eengine.rb
- Removed dead `transformer.rb` module

## Dependencies

- Requires https://github.com/parsanol/parsanol-rs/pull/49 (dead code cleanup - Tagged removal)

## Test plan

- [x] `bundle exec rspec spec/expressir` — 1342 tests pass
- [x] `bundle exec rubocop` — no offenses
- [ ] CI: all checks pass (after parsanol-rs PR #49 is merged and parsanol-ruby is updated)