### PR TITLE
fix: use relative paths in formatted YAML fixtures

### DIFF
--- a/spec/syntax/multiple_formatted.yaml
+++ b/spec/syntax/multiple_formatted.yaml
@@ -1,41 +1,41 @@
 ---
 _class: Expressir::Model::ExpFile
-path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp"
+path: spec/syntax/multiple.exp
 schemas:
 - _class: Expressir::Model::Declarations::Schema
   id: multiple_schema
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp"
+  file: spec/syntax/multiple.exp
   interfaces:
   - _class: Expressir::Model::Declarations::Interface
     kind: REFERENCE
     schema:
       _class: Expressir::Model::References::SimpleReference
       id: multiple_schema2
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema2"
+      base_path: spec/syntax/multiple.exp.multiple_schema2
   - _class: Expressir::Model::Declarations::Interface
     kind: REFERENCE
     schema:
       _class: Expressir::Model::References::SimpleReference
       id: multiple_schema3
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema3"
+      base_path: spec/syntax/multiple.exp.multiple_schema3
     items:
     - _class: Expressir::Model::Declarations::InterfaceItem
       ref:
         _class: Expressir::Model::References::SimpleReference
         id: attribute_entity3
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema3.attribute_entity3"
+        base_path: spec/syntax/multiple.exp.multiple_schema3.attribute_entity3
   - _class: Expressir::Model::Declarations::Interface
     kind: REFERENCE
     schema:
       _class: Expressir::Model::References::SimpleReference
       id: multiple_schema4
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema4"
+      base_path: spec/syntax/multiple.exp.multiple_schema4
     items:
     - _class: Expressir::Model::Declarations::InterfaceItem
       ref:
         _class: Expressir::Model::References::SimpleReference
         id: attribute_entity
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema4.attribute_entity"
+        base_path: spec/syntax/multiple.exp.multiple_schema4.attribute_entity
       id: attribute_entity4
   entities:
   - _class: Expressir::Model::Declarations::Entity
@@ -55,13 +55,13 @@ schemas:
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: empty_entity
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema.empty_entity"
+      base_path: spec/syntax/multiple.exp.multiple_schema.empty_entity
   - _class: Expressir::Model::Declarations::Entity
     id: subtype_attribute_entity
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: attribute_entity
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema.attribute_entity"
+      base_path: spec/syntax/multiple.exp.multiple_schema.attribute_entity
     attributes:
     - _class: Expressir::Model::Declarations::Attribute
       id: test
@@ -76,7 +76,7 @@ schemas:
           entity:
             _class: Expressir::Model::References::SimpleReference
             id: attribute_entity
-            base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema.attribute_entity"
+            base_path: spec/syntax/multiple.exp.multiple_schema.attribute_entity
         attribute:
           _class: Expressir::Model::References::SimpleReference
           id: test
@@ -87,7 +87,7 @@ schemas:
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: attribute_entity2
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema2.attribute_entity2"
+      base_path: spec/syntax/multiple.exp.multiple_schema2.attribute_entity2
     attributes:
     - _class: Expressir::Model::Declarations::Attribute
       id: test
@@ -102,7 +102,7 @@ schemas:
           entity:
             _class: Expressir::Model::References::SimpleReference
             id: attribute_entity2
-            base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema2.attribute_entity2"
+            base_path: spec/syntax/multiple.exp.multiple_schema2.attribute_entity2
         attribute:
           _class: Expressir::Model::References::SimpleReference
           id: test
@@ -113,7 +113,7 @@ schemas:
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: attribute_entity3
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema3.attribute_entity3"
+      base_path: spec/syntax/multiple.exp.multiple_schema3.attribute_entity3
     attributes:
     - _class: Expressir::Model::Declarations::Attribute
       id: test
@@ -128,7 +128,7 @@ schemas:
           entity:
             _class: Expressir::Model::References::SimpleReference
             id: attribute_entity3
-            base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema3.attribute_entity3"
+            base_path: spec/syntax/multiple.exp.multiple_schema3.attribute_entity3
         attribute:
           _class: Expressir::Model::References::SimpleReference
           id: test
@@ -139,7 +139,7 @@ schemas:
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: attribute_entity4
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema4.attribute_entity"
+      base_path: spec/syntax/multiple.exp.multiple_schema4.attribute_entity
     attributes:
     - _class: Expressir::Model::Declarations::Attribute
       id: test
@@ -154,7 +154,7 @@ schemas:
           entity:
             _class: Expressir::Model::References::SimpleReference
             id: attribute_entity4
-            base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp.multiple_schema4.attribute_entity"
+            base_path: spec/syntax/multiple.exp.multiple_schema4.attribute_entity
         attribute:
           _class: Expressir::Model::References::SimpleReference
           id: test
@@ -167,7 +167,7 @@ schemas:
       id: missing_entity
 - _class: Expressir::Model::Declarations::Schema
   id: multiple_schema2
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp"
+  file: spec/syntax/multiple.exp
   entities:
   - _class: Expressir::Model::Declarations::Entity
     id: attribute_entity2
@@ -179,7 +179,7 @@ schemas:
         _class: Expressir::Model::DataTypes::Boolean
 - _class: Expressir::Model::Declarations::Schema
   id: multiple_schema3
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp"
+  file: spec/syntax/multiple.exp
   entities:
   - _class: Expressir::Model::Declarations::Entity
     id: attribute_entity3
@@ -191,7 +191,7 @@ schemas:
         _class: Expressir::Model::DataTypes::Boolean
 - _class: Expressir::Model::Declarations::Schema
   id: multiple_schema4
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/multiple.exp"
+  file: spec/syntax/multiple.exp
   entities:
   - _class: Expressir::Model::Declarations::Entity
     id: attribute_entity

--- a/spec/syntax/remark_formatted.yaml
+++ b/spec/syntax/remark_formatted.yaml
@@ -1,6 +1,6 @@
 ---
 _class: Expressir::Model::ExpFile
-path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp"
+path: spec/syntax/remark.exp
 schemas:
 - _class: Expressir::Model::Declarations::Schema
   id: remark_schema
@@ -19,7 +19,7 @@ schemas:
     remarks:
     - schema scope - schema remark item
     - universal scope - schema remark item
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp"
+  file: spec/syntax/remark.exp
   constants:
   - _class: Expressir::Model::Declarations::Constant
     id: remark_constant
@@ -112,11 +112,11 @@ schemas:
       type:
         _class: Expressir::Model::References::SimpleReference
         id: remark_entity
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_entity"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity
       expression:
         _class: Expressir::Model::References::SimpleReference
         id: remark_attribute
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
     unique_rules:
     - _class: Expressir::Model::Declarations::UniqueRule
       id: UR1
@@ -127,7 +127,7 @@ schemas:
       attributes:
       - _class: Expressir::Model::References::SimpleReference
         id: remark_attribute
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
       id: WR1
@@ -169,7 +169,7 @@ schemas:
     applies_to:
       _class: Expressir::Model::References::SimpleReference
       id: remark_entity
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_entity"
+      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
     abstract: false
   functions:
   - _class: Expressir::Model::Declarations::Function
@@ -237,7 +237,7 @@ schemas:
       expression:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_function.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
       statements:
       - _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Statements::Repeat
@@ -256,7 +256,7 @@ schemas:
       ref:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_function.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
       expression:
         _class: Expressir::Model::Expressions::QueryExpression
         id: remark_query
@@ -265,7 +265,7 @@ schemas:
         aggregate_source:
           _class: Expressir::Model::References::SimpleReference
           id: remark_variable
-          base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_function.remark_variable"
+          base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: 'TRUE'
@@ -278,7 +278,7 @@ schemas:
     applies_to:
     - _class: Expressir::Model::References::SimpleReference
       id: remark_entity
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_entity"
+      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
     types:
     - _class: Expressir::Model::Declarations::Type
       id: remark_type
@@ -327,7 +327,7 @@ schemas:
       expression:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
       statements:
       - _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Statements::Repeat
@@ -346,7 +346,7 @@ schemas:
       ref:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
       expression:
         _class: Expressir::Model::Expressions::QueryExpression
         id: remark_query
@@ -355,7 +355,7 @@ schemas:
         aggregate_source:
           _class: Expressir::Model::References::SimpleReference
           id: remark_variable
-          base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable"
+          base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: 'TRUE'
@@ -451,7 +451,7 @@ schemas:
       expression:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
       statements:
       - _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Statements::Repeat
@@ -470,7 +470,7 @@ schemas:
       ref:
         _class: Expressir::Model::References::SimpleReference
         id: remark_variable
-        base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable"
+        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
       expression:
         _class: Expressir::Model::Expressions::QueryExpression
         id: remark_query
@@ -479,7 +479,7 @@ schemas:
         aggregate_source:
           _class: Expressir::Model::References::SimpleReference
           id: remark_variable
-          base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable"
+          base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: 'TRUE'

--- a/spec/syntax/single_formatted.yaml
+++ b/spec/syntax/single_formatted.yaml
@@ -1,10 +1,10 @@
 ---
 _class: Expressir::Model::ExpFile
-path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/single.exp"
+path: spec/syntax/single.exp
 schemas:
 - _class: Expressir::Model::Declarations::Schema
   id: single_schema
-  file: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/single.exp"
+  file: spec/syntax/single.exp
   version:
     _class: Expressir::Model::Declarations::SchemaVersion
     value: version
@@ -16,4 +16,4 @@ schemas:
     subtype_of:
     - _class: Expressir::Model::References::SimpleReference
       id: empty_entity
-      base_path: "/Users/mulgogi/src/lutaml/expressir/spec/syntax/single.exp.single_schema.empty_entity"
+      base_path: spec/syntax/single.exp.single_schema.empty_entity


### PR DESCRIPTION
The YAML fixtures (single_formatted.yaml, multiple_formatted.yaml, remark_formatted.yaml) were regenerated with absolute local paths. Fix by passing root_path to Parser.from_file to get relative paths as the originals had.