### PR TITLE
fix: remove absolute paths from fixture files

### DIFF
--- a/spec/fixtures/changes/eengine-geometry_schema.xml
+++ b/spec/fixtures/changes/eengine-geometry_schema.xml
@@ -3,9 +3,9 @@
 <!--   5.2.7 (GIT eeng-5.2.7) -->
 <!--   Steel Bank CL 2.5.8 (Unknown Bits) -->
 <!-- Reference_Schema: GEOMETRY_SCHEMA -->
-<!-- Path:   /Users/mulgogi/src/mn/iso-10303/schemas/resources/geometry_schema/geometry_schema_v11.exp -->
+<!-- Path:   geometry_schema_v11.exp -->
 <!-- Trial_schema: GEOMETRY_SCHEMA -->
-<!-- Path:   /Users/mulgogi/src/mn/iso-10303/schemas/resources/geometry_schema/geometry_schema_v13.exp -->
+<!-- Path:   geometry_schema_v13.exp -->
 
 
 <schema.modifications>

--- a/spec/fixtures/empty_schema-list.txt
+++ b/spec/fixtures/empty_schema-list.txt
@@ -4,7 +4,7 @@
 *** Express Engine Command Line:
 ***   eengine --list
 ***     -SCHEMA spec/fixtures/empty_schema.exp
-*** File: /Users/mulgogi/src/lutaml/expressir/spec/fixtures/empty_schema.exp
+*** File: spec/fixtures/empty_schema.exp
 *** 1 Schema:
    empty_schema
 

--- a/spec/fixtures/examples/cloud_computing_foundation_schema-list.txt
+++ b/spec/fixtures/examples/cloud_computing_foundation_schema-list.txt
@@ -4,7 +4,7 @@
 *** Express Engine Command Line:
 ***   eengine --list
 ***     -SCHEMA spec/fixtures/examples/cloud_computing_foundation_schema.exp
-*** File: /Users/mulgogi/src/lutaml/expressir/spec/fixtures/examples/cloud_computing_foundation_schema.exp
+*** File: spec/fixtures/examples/cloud_computing_foundation_schema.exp
 *** 1 Schema:
    cloud_computing_foundation_schema
 

--- a/spec/fixtures/examples/cybersecurity_threat_detection_schema-list.txt
+++ b/spec/fixtures/examples/cybersecurity_threat_detection_schema-list.txt
@@ -4,7 +4,7 @@
 *** Express Engine Command Line:
 ***   eengine --list
 ***     -SCHEMA spec/fixtures/examples/cybersecurity_threat_detection_schema.exp
-*** File: /Users/mulgogi/src/lutaml/expressir/spec/fixtures/examples/cybersecurity_threat_detection_schema.exp
+*** File: spec/fixtures/examples/cybersecurity_threat_detection_schema.exp
 *** 1 Schema:
    cybersecurity_threat_detection_schema
 

--- a/spec/fixtures/examples/nested_functions_test_schema-list.txt
+++ b/spec/fixtures/examples/nested_functions_test_schema-list.txt
@@ -4,7 +4,7 @@
 *** Express Engine Command Line:
 ***   eengine --list
 ***     -SCHEMA spec/fixtures/examples/nested_functions_test_schema.exp
-*** File: /Users/mulgogi/src/lutaml/expressir/spec/fixtures/examples/nested_functions_test_schema.exp
+*** File: spec/fixtures/examples/nested_functions_test_schema.exp
 *** 1 Schema:
    nested_functions_test_schema
 


### PR DESCRIPTION
Strip absolute local paths from unused fixture files (list.txt and XML) that contained  paths. No tests reference these files.