### PR TITLE
fix: formatter roundtrip for group qualifications, intervals, and expressions (#300)

### DIFF
--- a/lib/expressir/express/builder.rb
+++ b/lib/expressir/express/builder.rb
@@ -354,7 +354,7 @@ module Expressir
         end
 
         def attach_source_info(result, data)
-          return unless @source && result.is_a?(Model::ModelElement)
+          return unless @source && result.is_a?(Expressir::Model::ModelElement)
 
           source_info = extract_source_info(data)
           return unless source_info

--- a/lib/expressir/express/builder_registry.rb
+++ b/lib/expressir/express/builder_registry.rb
@@ -181,18 +181,18 @@ module Expressir
       Builder.register(:interval_high) { |d| expression.build_interval_high(d) }
       Builder.register(:interval_item) { |d| expression.build_interval_item(d) }
       Builder.register(:interval_op) do |d|
-        expression.send(:extract_interval_op, d)
+        expression.extract_interval_op(d)
       end
 
       # Operators
       Builder.register(:add_like_op) do |d|
-        expression.send(:extract_operator, d)
+        expression.extract_operator(d)
       end
       Builder.register(:mul_like_op) do |d|
-        expression.send(:extract_operator, d)
+        expression.extract_operator(d)
       end
-      Builder.register(:unary_op) { |d| expression.send(:extract_unary_op, d) }
-      Builder.register(:rel_op) { |d| expression.send(:extract_rel_op, d) }
+      Builder.register(:unary_op) { |d| expression.extract_unary_op(d) }
+      Builder.register(:rel_op) { |d| expression.extract_rel_op(d) }
 
       # ========================================================================
       # Interface Builder (closures)
@@ -319,45 +319,20 @@ module Expressir
         subtype_constraint.build_total_over(d)
       end
 
-      Builder.register(:subtype_constraint_decl) do |d|
-        subtype_constraint.build_subtype_constraint_decl(d)
-      end
-      Builder.register(:total_over) do |d|
-        subtype_constraint.build_total_over(d)
-      end
-      Builder.register(:supertype_expression) do |d|
-        subtype_constraint.build_supertype_expression(d)
-      end
-      Builder.register(:supertype_factor) do |d|
-        subtype_constraint.build_supertype_factor(d)
-      end
-      Builder.register(:supertype_term) do |d|
-        subtype_constraint.build_supertype_term(d)
-      end
-      Builder.register(:one_of) { |d| subtype_constraint.build_one_of(d) }
-      Builder.register(:supertype_rule) do |d|
-        subtype_constraint.build_supertype_rule(d)
-      end
-      Builder.register(:subtype_constraint) do |d|
-        subtype_constraint.build_subtype_constraint(d)
-      end
-      Builder.register(:subtype_declaration) do |d|
-        subtype_constraint.build_subtype_declaration(d)
-      end
-
       # ========================================================================
       # Type Builder (closures)
       # ========================================================================
 
       # Simple types
-      %i[boolean_type integer_type logical_type number_type].each do |type|
-        Builder.register(type) { |d| type_builder.send(:"build_#{type}", d) }
-      end
+      Builder.register(:boolean_type) { |d| type_builder.build_boolean_type(d) }
+      Builder.register(:integer_type) { |d| type_builder.build_integer_type(d) }
+      Builder.register(:logical_type) { |d| type_builder.build_logical_type(d) }
+      Builder.register(:number_type) { |d| type_builder.build_number_type(d) }
 
       # Type constructors
       Builder.register(:generic_type) { |_d| Expressir::Model::DataTypes::Generic.new }
       Builder.register(:generic_entity_type) { |_d| Expressir::Model::DataTypes::GenericEntity.new }
-      Builder.register(:aggregate_type) { |_d| Expressir::Model::DataTypes::Aggregate.new }
+      Builder.register(:aggregate_type) { |d| type_builder.build_aggregate_type(d) }
       Builder.register(:general_set_type) do |d|
         type_builder.build_general_set_type(d)
       end

--- a/lib/expressir/express/builders/constant_builder.rb
+++ b/lib/expressir/express/builders/constant_builder.rb
@@ -36,7 +36,10 @@ module Expressir
           ids = if ids_data.is_a?(Hash)
                   [Builder.build({ variable_id: ids_data })]
                 elsif ids_data.is_a?(Array)
-                  ids_data.map { |id| Builder.build({ variable_id: id }) }
+                  ids_data.filter_map do |elem|
+                    actual_id = elem[:variable_id] || elem
+                    Builder.build({ variable_id: actual_id })
+                  end
                 else
                   []
                 end
@@ -64,7 +67,10 @@ module Expressir
           ids = if ids_data.is_a?(Hash)
                   [Builder.build({ parameter_id: ids_data })]
                 elsif ids_data.is_a?(Array)
-                  ids_data.map { |id| Builder.build({ parameter_id: id }) }
+                  ids_data.filter_map do |elem|
+                    actual_id = elem[:parameter_id] || elem
+                    Builder.build({ parameter_id: actual_id })
+                  end
                 else
                   []
                 end

--- a/lib/expressir/express/builders/procedure_decl_builder.rb
+++ b/lib/expressir/express/builders/procedure_decl_builder.rb
@@ -62,7 +62,8 @@ module Expressir
 
           parameters = []
           Builder.ensure_array(params_data).each do |param|
-            result = Builder.build({ procedure_head_parameter: param })
+            actual_param = param[:procedure_head_parameter] || param
+            result = Builder.build({ procedure_head_parameter: actual_param })
             parameters.concat(Builder.ensure_array(result)) if result
           end
           parameters

--- a/lib/expressir/express/builders/statement_builder.rb
+++ b/lib/expressir/express/builders/statement_builder.rb
@@ -85,12 +85,14 @@ module Expressir
         def build_case_stmt(ast_data)
           selector = Builder.build_optional(ast_data[:selector])
           actions = Builder.build_children(ast_data[:case_action])
-          otherwise = Builder.build_children(ast_data[:otherwise]&.dig(:stmt))
+          otherwise_stmt = if ast_data[:t_otherwise] && ast_data[:stmt].is_a?(Hash)
+                             Builder.build({ stmt: ast_data[:stmt] })
+                           end
 
           Expressir::Model::Statements::Case.new(
             expression: selector,
             actions: actions.compact,
-            otherwise: otherwise.compact,
+            otherwise_statement: otherwise_stmt,
           )
         end
 
@@ -101,12 +103,23 @@ module Expressir
         end
 
         def build_case_action(ast_data)
-          labels = Builder.build_children(ast_data[:case_label])
-          statements = Builder.build_children(ast_data[:stmt])
+          label_data = ast_data[:list_of_case_label]
+          labels = if label_data.is_a?(Hash)
+                     Builder.build_children(label_data[:case_label])
+                   elsif label_data.is_a?(Array)
+                     label_data.flat_map do |item|
+                       Builder.build_children(item.is_a?(Hash) ? item[:case_label] : item)
+                     end
+                   else
+                     []
+                   end
+          stmt = if ast_data[:stmt].is_a?(Hash)
+                   Builder.build({ stmt: ast_data[:stmt] })
+                 end
 
           Expressir::Model::Statements::CaseAction.new(
             labels: labels.compact,
-            statements: statements.compact,
+            statement: stmt,
           )
         end
 

--- a/lib/expressir/express/builders/type_builder.rb
+++ b/lib/expressir/express/builders/type_builder.rb
@@ -7,18 +7,20 @@ module Expressir
       class TypeBuilder
         include ::Expressir::Express::Builders::Helpers
 
-        # Simple types
-        {
-          boolean_type: Expressir::Model::DataTypes::Boolean,
-          integer_type: Expressir::Model::DataTypes::Integer,
-          logical_type: Expressir::Model::DataTypes::Logical,
-          number_type: Expressir::Model::DataTypes::Number,
-          generic_type: Expressir::Model::DataTypes::Generic,
-          generic_entity_type: Expressir::Model::DataTypes::GenericEntity,
-        }.each do |type_name, klass|
-          define_method(:"build_#{type_name}") do |_ast_data|
-            klass.new
-          end
+        def build_boolean_type(_ast_data)
+          Expressir::Model::DataTypes::Boolean.new
+        end
+
+        def build_integer_type(_ast_data)
+          Expressir::Model::DataTypes::Integer.new
+        end
+
+        def build_logical_type(_ast_data)
+          Expressir::Model::DataTypes::Logical.new
+        end
+
+        def build_number_type(_ast_data)
+          Expressir::Model::DataTypes::Number.new
         end
 
         # String type
@@ -47,6 +49,12 @@ module Expressir
           else
             Expressir::Model::DataTypes::Real.new
           end
+        end
+
+        # Aggregate type (AGGREGATE OF type)
+        def build_aggregate_type(ast_data)
+          base_type = Builder.build_optional(ast_data[:parameter_type])
+          Expressir::Model::DataTypes::Aggregate.new(base_type: base_type)
         end
 
         # Aggregation types

--- a/lib/expressir/express/formatters/data_types_formatter.rb
+++ b/lib/expressir/express/formatters/data_types_formatter.rb
@@ -4,8 +4,18 @@ module Expressir
       module DataTypesFormatter
         private
 
-        def format_data_types_aggregate(_node)
-          "AGGREGATE"
+        def format_data_types_aggregate(node)
+          [
+            "AGGREGATE",
+            *if node.base_type
+               [
+                 " ",
+                 "OF",
+                 " ",
+                 format(node.base_type),
+               ]
+             end,
+          ].join
         end
 
         def format_data_types_array(node)
@@ -257,7 +267,7 @@ module Expressir
                     ].join
                   end,
                ].join
-             else
+             elsif node.items&.length&.positive?
                indent_char = self.class.const_get(:INDENT_CHAR)
                item_indent = indent_char * "(".length
                [

--- a/lib/expressir/express/formatters/expressions_formatter.rb
+++ b/lib/expressir/express/formatters/expressions_formatter.rb
@@ -24,9 +24,9 @@ module Expressir
         def format_expressions_binary_expression(node)
           operator_precedence = self.class.const_get(:OPERATOR_PRECEDENCE)
           op1_bin_exp = node.operand1.is_a?(Model::Expressions::BinaryExpression) &&
-            (operator_precedence[node.operand1.operator] > operator_precedence[node.operator])
+            (operator_precedence[node.operand1.operator] >= operator_precedence[node.operator])
           op2_bin_exp = node.operand2.is_a?(Model::Expressions::BinaryExpression) &&
-            (operator_precedence[node.operand2.operator] > operator_precedence[node.operator])
+            (operator_precedence[node.operand2.operator] >= operator_precedence[node.operator])
 
           [
             *if op1_bin_exp
@@ -138,6 +138,9 @@ module Expressir
         end
 
         def format_expressions_unary_expression(node)
+          needs_parens = node.operand.is_a?(Model::Expressions::BinaryExpression) ||
+            node.operand.is_a?(Model::Expressions::Interval)
+
           [
             case node.operator
             when Model::Expressions::UnaryExpression::MINUS then "-"
@@ -147,11 +150,11 @@ module Expressir
             if node.operator == Model::Expressions::UnaryExpression::NOT
               " "
             end,
-            *if node.operand.is_a? Model::Expressions::BinaryExpression
+            *if needs_parens
                "("
              end,
             format(node.operand),
-            *if node.operand.is_a? Model::Expressions::BinaryExpression
+            *if needs_parens
                ")"
              end,
           ].join

--- a/lib/expressir/express/formatters/literals_formatter.rb
+++ b/lib/expressir/express/formatters/literals_formatter.rb
@@ -5,10 +5,7 @@ module Expressir
         private
 
         def format_literals_binary(node)
-          [
-            "%",
-            node.value,
-          ].join
+          node.value
         end
 
         def format_literals_integer(node)

--- a/lib/expressir/express/remark_attacher.rb
+++ b/lib/expressir/express/remark_attacher.rb
@@ -525,7 +525,7 @@ module Expressir
       def find_target_in_where_clause(scope, tag, remark_line)
         return nil unless supports_where_rules?(scope)
 
-        where_rules = scope.where_rules
+        where_rules = safe_get_collection(scope, :where_rules)
         return nil unless where_rules&.any?
 
         # Search source text for WHERE clause containing this remark

--- a/lib/expressir/model/declarations/function.rb
+++ b/lib/expressir/model/declarations/function.rb
@@ -6,7 +6,6 @@ module Expressir
       class Function < ModelElement
         include Identifier
         include ScopeContainer
-        include HasWhereRules
 
         attribute :parameters, Parameter, collection: true
         attribute :return_type, ModelElement

--- a/lib/expressir/model/declarations/procedure.rb
+++ b/lib/expressir/model/declarations/procedure.rb
@@ -6,7 +6,6 @@ module Expressir
       class Procedure < ModelElement
         include Identifier
         include ScopeContainer
-        include HasWhereRules
 
         attribute :parameters, Parameter, collection: true
         attribute :types, ModelElement, collection: true

--- a/spec/expressir/express/formatter_roundtrip_spec.rb
+++ b/spec/expressir/express/formatter_roundtrip_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+
+RSpec.describe Expressir::Express::Formatter do
+  def assert_roundtrip(exp_text)
+    repo1 = Expressir::Express::Parser.from_exp(exp_text, use_native: false)
+    formatted1 = described_class.format(repo1)
+
+    repo2 = Expressir::Express::Parser.from_exp(formatted1, use_native: false)
+    formatted2 = described_class.format(repo2)
+
+    strip = ->(t) { t.lines.reject { |l| l.strip.start_with?("--") || l.strip.empty? }.join }
+    expect(strip.call(formatted1)).to(
+      eq(strip.call(formatted2)),
+      "Structural content should be stable across format iterations",
+    )
+  end
+
+  def parse(exp_text)
+    Expressir::Express::Parser.from_exp(exp_text, use_native: false)
+  end
+
+  describe "unary expression with interval operand" do
+    it "wraps interval in parens when negated (NOT {interval})" do
+      exp_text = "SCHEMA t; FUNCTION f : BOOLEAN; " \
+                 "IF NOT ({1 <= 2 <= 3}) THEN RETURN (TRUE); END_IF; " \
+                 "END_FUNCTION; END_SCHEMA;"
+      assert_roundtrip(exp_text)
+    end
+
+    it "formats NOT ({interval}) correctly" do
+      repo = parse("SCHEMA t; FUNCTION f : BOOLEAN; " \
+                   "IF NOT ({1 <= 2 <= 3}) THEN RETURN (TRUE); END_IF; " \
+                   "END_FUNCTION; END_SCHEMA;")
+
+      formatted = described_class.format(repo)
+      expect(formatted).to include("NOT ({1 <= 2 <= 3})")
+      expect(formatted).not_to include("NOT {1 <= 2 <= 3}")
+    end
+  end
+
+  describe "shorthand variable declarations" do
+    it "preserves multiple variables declared on one line" do
+      repo = parse("SCHEMA t; FUNCTION f : INTEGER; " \
+                   "LOCAL slo, shi : INTEGER; END_LOCAL; " \
+                   "RETURN (slo + shi); END_FUNCTION; END_SCHEMA;")
+
+      func = repo.schemas.first.functions.first
+      expect(func.variables.length).to eq(2)
+      expect(func.variables[0].id).to eq("slo")
+      expect(func.variables[1].id).to eq("shi")
+      expect(func.variables[0].type).to eq(func.variables[1].type)
+    end
+
+    it "roundtrips shorthand variable declarations" do
+      exp_text = "SCHEMA t; FUNCTION f : INTEGER; " \
+                 "LOCAL slo, shi : INTEGER; END_LOCAL; " \
+                 "RETURN (slo + shi); END_FUNCTION; END_SCHEMA;"
+      assert_roundtrip(exp_text)
+    end
+  end
+
+  describe "procedure VAR parameters" do
+    it "preserves VAR parameter flag" do
+      repo = parse("SCHEMA t; PROCEDURE p(x : INTEGER; VAR y : INTEGER); " \
+                   "END_PROCEDURE; END_SCHEMA;")
+
+      proc = repo.schemas.first.procedures.first
+      expect(proc.parameters.length).to eq(2)
+      expect(proc.parameters[0].var).to be_nil
+      expect(proc.parameters[1].var).to be(true)
+    end
+  end
+
+  describe "group qualification with index qualifier" do
+    it "roundtrips group-qualified index expressions" do
+      exp_text = "SCHEMA t; " \
+                 "ENTITY sup; field : LIST OF INTEGER; END_ENTITY; " \
+                 "ENTITY sub SUBTYPE OF (sup); inc : LIST OF INTEGER; END_ENTITY; " \
+                 "FUNCTION f(x : sup) : BOOLEAN; " \
+                 "LOCAL v : INTEGER; END_LOCAL; " \
+                 "v := x\\sub.field[1]; " \
+                 "IF x\\sub.inc[2] >= 0 THEN RETURN (TRUE); END_IF; " \
+                 "RETURN (FALSE); END_FUNCTION; END_SCHEMA;"
+      assert_roundtrip(exp_text)
+    end
+  end
+
+  describe "binary expression parenthesization" do
+    it "adds parens for same-precedence left-associative operators" do
+      repo = parse("SCHEMA t; FUNCTION f : INTEGER; " \
+                   "LOCAL x : INTEGER; END_LOCAL; " \
+                   "x := 4 + 2 + 1; RETURN (x); END_FUNCTION; END_SCHEMA;")
+
+      formatted = described_class.format(repo)
+      expect(formatted).to include("(4 + 2) + 1")
+    end
+
+    it "roundtrips chained binary expressions" do
+      exp_text = "SCHEMA t; FUNCTION f : BOOLEAN; " \
+                 "LOCAL x : INTEGER; END_LOCAL; " \
+                 "x := (4 + 2) - 1; RETURN (x > 0); END_FUNCTION; END_SCHEMA;"
+      assert_roundtrip(exp_text)
+    end
+  end
+
+  describe "binary literals" do
+    it "preserves binary literal formatting" do
+      repo = parse("SCHEMA t; FUNCTION f : BOOLEAN; " \
+                   "LOCAL x : BINARY; END_LOCAL; " \
+                   "x := %01010101; RETURN (TRUE); END_FUNCTION; END_SCHEMA;")
+
+      formatted = described_class.format(repo)
+      expect(formatted).to include("%01010101")
+    end
+  end
+
+  describe "syntax.exp full roundtrip" do
+    it "roundtrips syntax.exp structural content" do
+      exp_file = Expressir.root_path.join("spec", "syntax", "syntax.exp")
+      repo1 = Expressir::Express::Parser.from_file(exp_file)
+      formatted1 = described_class.format(repo1)
+
+      repo2 = Expressir::Express::Parser.from_exp(formatted1, use_native: false)
+      formatted2 = described_class.format(repo2)
+
+      strip = ->(t) { t.lines.reject { |l| l.strip.start_with?("--") || l.strip.empty? }.join }
+      expect(strip.call(formatted1)).to eq(strip.call(formatted2))
+    end
+  end
+end

--- a/spec/syntax/remark_parser.yaml
+++ b/spec/syntax/remark_parser.yaml
@@ -1,485 +1,3592 @@
 ---
 _class: Expressir::Model::ExpFile
-path: spec/syntax/remark.exp
+path: spec/syntax/syntax.exp
 schemas:
 - _class: Expressir::Model::Declarations::Schema
-  id: remark_schema
+  id: syntax_schema
   remarks:
-  - |-
-    Any character within the EXPRESS character set may occur between the start and end of
-    an embedded remark including the newline character; therefore, embedded remarks can span
-    several physical lines.
-  - The tail remark is written at the end of a physical line.
-  - 'UTF8 test: Příliš žluťoučký kůň úpěl ďábelské ódy.'
-  - universal scope - schema before
-  - universal scope - schema
-  remark_items:
-  - _class: Expressir::Model::Declarations::RemarkItem
-    id: remark_item
-    remarks:
-    - schema scope - schema remark item
-    - universal scope - schema remark item
-  file: spec/syntax/remark.exp
+  - interfaces
+  - constants
+  - types
+  untagged_remarks:
+  - text: interfaces
+    format: tail
+  - text: constants
+    format: tail
+  - text: types
+    format: tail
+  file: spec/syntax/syntax.exp
+  version:
+    _class: Expressir::Model::Declarations::SchemaVersion
+    value: "{ISO standard 10303 part(41) object(1) version(8)}"
+    items:
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      name: ISO
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      name: standard
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      value: '10303'
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      name: part
+      value: '41'
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      name: object
+      value: '1'
+    - _class: Expressir::Model::Declarations::SchemaVersionItem
+      name: version
+      value: '8'
+  interfaces:
+  - _class: Expressir::Model::Declarations::Interface
+    kind: USE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+  - _class: Expressir::Model::Declarations::Interface
+    kind: USE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+  - _class: Expressir::Model::Declarations::Interface
+    kind: USE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract2
+  - _class: Expressir::Model::Declarations::Interface
+    kind: USE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+      id: contract2
+  - _class: Expressir::Model::Declarations::Interface
+    kind: REFERENCE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+  - _class: Expressir::Model::Declarations::Interface
+    kind: REFERENCE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+  - _class: Expressir::Model::Declarations::Interface
+    kind: REFERENCE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract2
+  - _class: Expressir::Model::Declarations::Interface
+    kind: REFERENCE
+    schema:
+      _class: Expressir::Model::References::SimpleReference
+      id: contract_schema
+    items:
+    - _class: Expressir::Model::Declarations::InterfaceItem
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: contract
+      id: contract2
   constants:
   - _class: Expressir::Model::Declarations::Constant
-    id: remark_constant
-    remarks:
-    - schema scope - constant
-    - universal scope - constant
+    id: empty_constant
     type:
-      _class: Expressir::Model::DataTypes::String
+      _class: Expressir::Model::DataTypes::Boolean
     expression:
-      _class: Expressir::Model::Literals::String
-      value: xxx
+      _class: Expressir::Model::Literals::Logical
+      value: 'TRUE'
   types:
   - _class: Expressir::Model::Declarations::Type
-    id: remark_type
-    remarks:
-    - schema scope - type
-    - universal scope - type
+    id: empty_type
     underlying_type:
-      _class: Expressir::Model::DataTypes::Enumeration
-      items:
-      - _class: Expressir::Model::DataTypes::EnumerationItem
-        id: remark_enumeration_item
-        remarks:
-        - schema scope - enumeration item
-        - schema scope - enumeration item, on the same level as the type
-        - universal scope - enumeration item
-        - universal scope - enumeration item, on the same level as the type
+      _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Type
+    id: where_type
+    underlying_type:
+      _class: Expressir::Model::DataTypes::Boolean
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
-      id: WR1
-      remarks:
-      - type scope - type where
-      - type scope - type where, with prefix
-      - schema scope - type where
-      - schema scope - type where, with prefix
-      - universal scope - type where
-      - universal scope - type where, with prefix
       expression:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
-    informal_propositions:
-    - _class: Expressir::Model::Declarations::InformalPropositionRule
-      id: IP1
-      remarks:
-      - type scope - type informal proposition, with prefix
-      - schema scope - type informal proposition
-      - schema scope - type informal proposition, with prefix
-      - universal scope - type informal proposition
-      - universal scope - type informal proposition, with prefix
-      remark_items:
-      - _class: Expressir::Model::Declarations::RemarkItem
-        id: IP1
-        remarks:
-        - type scope - type informal proposition
+  - _class: Expressir::Model::Declarations::Type
+    id: where_label_type
+    remarks:
+    - entities
+    untagged_remarks:
+    - text: entities
+      format: tail
+    underlying_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      id: WR1
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
   entities:
   - _class: Expressir::Model::Declarations::Entity
-    id: remark_entity
-    remarks:
-    - schema scope - entity
-    - universal scope - entity
+    id: empty_entity
+  - _class: Expressir::Model::Declarations::Entity
+    id: abstract_entity
+    abstract: true
+  - _class: Expressir::Model::Declarations::Entity
+    id: abstract_supertype_entity
+    abstract: true
+  - _class: Expressir::Model::Declarations::Entity
+    id: abstract_supertype_constraint_entity
+    abstract: true
+    supertype_expression:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+  - _class: Expressir::Model::Declarations::Entity
+    id: supertype_constraint_entity
+    supertype_expression:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+  - _class: Expressir::Model::Declarations::Entity
+    id: subtype_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+  - _class: Expressir::Model::Declarations::Entity
+    id: supertype_constraint_subtype_entity
+    supertype_expression:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_entity
     attributes:
     - _class: Expressir::Model::Declarations::Attribute
-      id: remark_attribute
-      remarks:
-      - entity scope - entity attribute
-      - schema scope - entity attribute
-      - universal scope - entity attribute
+      id: test
       kind: EXPLICIT
       type:
-        _class: Expressir::Model::DataTypes::String
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_optional_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      optional: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_multiple_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test2
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_multiple_shorthand_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test2
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_redeclared_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: attribute_redeclared_renamed_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test2
+      kind: EXPLICIT
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Entity
+    id: derived_attribute_entity
+    attributes:
     - _class: Expressir::Model::Declarations::DerivedAttribute
-      id: remark_derived_attribute
-      remarks:
-      - entity scope - entity derived attribute
-      - schema scope - entity derived attribute
-      - universal scope - entity derived attribute
+      id: test
       kind: DERIVED
       type:
-        _class: Expressir::Model::DataTypes::String
+        _class: Expressir::Model::DataTypes::Boolean
       expression:
-        _class: Expressir::Model::Literals::String
-        value: xxx
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Entity
+    id: derived_attribute_redeclared_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::DerivedAttribute
+      id: test
+      kind: DERIVED
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Entity
+    id: derived_attribute_redeclared_renamed_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::DerivedAttribute
+      id: test2
+      kind: DERIVED
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_entity
+    attributes:
     - _class: Expressir::Model::Declarations::InverseAttribute
-      id: remark_inverse_attribute
-      remarks:
-      - entity scope - entity inverse attribute
-      - schema scope - entity inverse attribute
-      - universal scope - entity inverse attribute
+      id: test
       kind: INVERSE
       type:
         _class: Expressir::Model::References::SimpleReference
-        id: remark_entity
-        base_path: spec/syntax/remark.exp.remark_schema.remark_entity
+        id: attribute_entity
+        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
       expression:
         _class: Expressir::Model::References::SimpleReference
-        id: remark_attribute
-        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_entity_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      type:
+        _class: Expressir::Model::References::SimpleReference
+        id: attribute_entity
+        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_set_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      type:
+        _class: Expressir::Model::DataTypes::Set
+        base_type:
+          _class: Expressir::Model::References::SimpleReference
+          id: attribute_entity
+          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_set_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_set_bound_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      type:
+        _class: Expressir::Model::DataTypes::Set
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        base_type:
+          _class: Expressir::Model::References::SimpleReference
+          id: attribute_entity
+          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_set_bound_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_bag_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      type:
+        _class: Expressir::Model::DataTypes::Bag
+        base_type:
+          _class: Expressir::Model::References::SimpleReference
+          id: attribute_entity
+          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_bag_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_bag_bound_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      type:
+        _class: Expressir::Model::DataTypes::Bag
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        base_type:
+          _class: Expressir::Model::References::SimpleReference
+          id: attribute_entity
+          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_bag_bound_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_redeclared_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test
+      kind: INVERSE
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::References::SimpleReference
+        id: attribute_entity
+        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_redeclared_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: inverse_attribute_redeclared_renamed_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: test2
+      kind: INVERSE
+      supertype_attribute:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+      type:
+        _class: Expressir::Model::References::SimpleReference
+        id: attribute_entity
+        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+  - _class: Expressir::Model::Declarations::Entity
+    id: unique_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    unique_rules:
+    - _class: Expressir::Model::Declarations::UniqueRule
+      attributes:
+      - _class: Expressir::Model::References::SimpleReference
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.unique_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: unique_label_entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: test
+      kind: EXPLICIT
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
     unique_rules:
     - _class: Expressir::Model::Declarations::UniqueRule
       id: UR1
-      remarks:
-      - entity scope - entity unique
-      - schema scope - entity unique
-      - universal scope - entity unique
       attributes:
       - _class: Expressir::Model::References::SimpleReference
-        id: remark_attribute
-        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
+        id: test
+        base_path: spec/syntax/syntax.exp.syntax_schema.unique_label_entity.test
+  - _class: Expressir::Model::Declarations::Entity
+    id: unique_redeclared_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    unique_rules:
+    - _class: Expressir::Model::Declarations::UniqueRule
+      attributes:
+      - _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+  - _class: Expressir::Model::Declarations::Entity
+    id: unique_label_redeclared_entity
+    subtype_of:
+    - _class: Expressir::Model::References::SimpleReference
+      id: attribute_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+    unique_rules:
+    - _class: Expressir::Model::Declarations::UniqueRule
+      id: UR1
+      attributes:
+      - _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: SELF
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: attribute_entity
+            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+  - _class: Expressir::Model::Declarations::Entity
+    id: where_entity
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
-      id: WR1
-      remarks:
-      - entity scope - entity where
-      - entity scope - entity where, with prefix
-      - schema scope - entity where
-      - schema scope - entity where, with prefix
-      - universal scope - entity where
-      - universal scope - entity where, with prefix
-      remark_items:
-      - _class: Expressir::Model::Declarations::RemarkItem
-        id: unusual_placement
-        remarks:
-        - placed inside WHERE clauses (or other enumerable context)
       expression:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
-    informal_propositions:
-    - _class: Expressir::Model::Declarations::InformalPropositionRule
-      id: IP1
-      remarks:
-      - entity scope - entity informal proposition, with prefix
-      - schema scope - entity informal proposition
-      - schema scope - entity informal proposition, with prefix
-      - universal scope - entity informal proposition
-      - universal scope - entity informal proposition, with prefix
-      remark_items:
-      - _class: Expressir::Model::Declarations::RemarkItem
-        id: IP1
-        remarks:
-        - entity scope - entity informal proposition
+  - _class: Expressir::Model::Declarations::Entity
+    id: where_label_entity
+    remarks:
+    - subtype constraints
+    untagged_remarks:
+    - text: subtype constraints
+      format: tail
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      id: WR1
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
   subtype_constraints:
   - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: remark_subtype_constraint
-    remarks:
-    - schema scope - subtype constraint
-    - universal scope - subtype constraint
+    id: empty_subtype_constraint
     applies_to:
       _class: Expressir::Model::References::SimpleReference
-      id: remark_entity
-      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
     abstract: false
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: abstract_supertype_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: true
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: total_over_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::References::SimpleReference
+      id: a
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_andor_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: b
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_and_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: b
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_andor_and_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::References::SimpleReference
+          id: b
+        operand2:
+          _class: Expressir::Model::References::SimpleReference
+          id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_and_andor_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::References::SimpleReference
+          id: a
+        operand2:
+          _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_parenthesis_andor_and_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+        operator: ANDOR
+        operand1:
+          _class: Expressir::Model::References::SimpleReference
+          id: a
+        operand2:
+          _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_and_parenthesis_andor_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+        operator: ANDOR
+        operand1:
+          _class: Expressir::Model::References::SimpleReference
+          id: b
+        operand2:
+          _class: Expressir::Model::References::SimpleReference
+          id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_oneof_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+      operands:
+      - _class: Expressir::Model::References::SimpleReference
+        id: a
+      - _class: Expressir::Model::References::SimpleReference
+        id: b
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_and_oneof_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+        - _class: Expressir::Model::References::SimpleReference
+          id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_andor_oneof_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::References::SimpleReference
+        id: a
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+        - _class: Expressir::Model::References::SimpleReference
+          id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_oneof_and_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: a
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_oneof_andor_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: a
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::References::SimpleReference
+        id: c
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_oneof_and_oneof_subtype_constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: AND
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: a
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: c
+        - _class: Expressir::Model::References::SimpleReference
+          id: d
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: supertype_expression_oneof_andor_oneof_subtype_constraint
+    remarks:
+    - functions
+    untagged_remarks:
+    - text: functions
+      format: tail
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    abstract: false
+    supertype_expression:
+      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
+      operator: ANDOR
+      operand1:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: a
+        - _class: Expressir::Model::References::SimpleReference
+          id: b
+      operand2:
+        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
+        operands:
+        - _class: Expressir::Model::References::SimpleReference
+          id: c
+        - _class: Expressir::Model::References::SimpleReference
+          id: d
   functions:
   - _class: Expressir::Model::Declarations::Function
-    id: remark_function
-    remarks:
-    - schema scope - function
-    - universal scope - function
+    id: empty_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: parameter_function
     parameters:
     - _class: Expressir::Model::Declarations::Parameter
-      id: remark_parameter
-      remarks:
-      - function scope - function parameter
-      - schema scope - function parameter
-      - universal scope - function parameter
+      id: test
       type:
-        _class: Expressir::Model::DataTypes::String
+        _class: Expressir::Model::DataTypes::Boolean
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_parameter_function
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_shorthand_parameter_function
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: type_function
     return_type:
       _class: Expressir::Model::DataTypes::Boolean
     types:
     - _class: Expressir::Model::Declarations::Type
-      id: remark_type
-      remarks:
-      - function scope - function type
-      - schema scope - function type
-      - universal scope - function type
+      id: test
       underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: remark_enumeration_item
-          remarks:
-          - function scope - function enumeration item
-          - function scope - function enumeration item, on the same level as the type
-          - schema scope - function enumeration item
-          - schema scope - function enumeration item, on the same level as the type
-          - universal scope - function enumeration item
-          - universal scope - function enumeration item, on the same level as the
-            type
+        _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: constant_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
     constants:
     - _class: Expressir::Model::Declarations::Constant
-      id: remark_constant
-      remarks:
-      - function scope - function constant
-      - schema scope - function constant
-      - universal scope - function constant
+      id: test
       type:
-        _class: Expressir::Model::DataTypes::String
-      expression:
-        _class: Expressir::Model::Literals::String
-        value: xxx
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: remark_variable
-      remarks:
-      - function scope - function variable
-      - schema scope - function variable
-      - universal scope - function variable
-      type:
-        _class: Expressir::Model::DataTypes::String
-    statements:
-    - _class: Expressir::Model::Statements::Alias
-      id: remark_alias
-      remarks:
-      - function alias scope - function alias
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Repeat
-      id: remark_repeat
-      remarks:
-      - function repeat scope - function repeat
-      bound1:
-        _class: Expressir::Model::Literals::Integer
-        value: '1'
-      bound2:
-        _class: Expressir::Model::Literals::Integer
-        value: '9'
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Assignment
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
-      expression:
-        _class: Expressir::Model::Expressions::QueryExpression
-        id: remark_query
-        remarks:
-        - function query scope - function query
-        aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-  rules:
-  - _class: Expressir::Model::Declarations::Rule
-    id: remark_rule
-    remarks:
-    - schema scope - rule
-    - universal scope - rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: remark_entity
-      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
-    types:
-    - _class: Expressir::Model::Declarations::Type
-      id: remark_type
-      remarks:
-      - rule scope - rule type
-      - schema scope - rule type
-      - universal scope - rule type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: remark_enumeration_item
-          remarks:
-          - rule scope - rule enumeration item
-          - rule scope - rule enumeration item, on the same level as the type
-          - schema scope - rule enumeration item
-          - schema scope - rule enumeration item, on the same level as the type
-          - universal scope - rule enumeration item
-          - universal scope - rule enumeration item, on the same level as the type
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: remark_constant
-      remarks:
-      - rule scope - rule constant
-      - schema scope - rule constant
-      - universal scope - rule constant
-      type:
-        _class: Expressir::Model::DataTypes::String
-      expression:
-        _class: Expressir::Model::Literals::String
-        value: xxx
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: remark_variable
-      remarks:
-      - rule scope - rule variable
-      - schema scope - rule variable
-      - universal scope - rule variable
-      type:
-        _class: Expressir::Model::DataTypes::String
-    statements:
-    - _class: Expressir::Model::Statements::Alias
-      id: remark_alias
-      remarks:
-      - rule alias scope - rule alias
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Repeat
-      id: remark_repeat
-      remarks:
-      - rule repeat scope - rule repeat
-      bound1:
-        _class: Expressir::Model::Literals::Integer
-        value: '1'
-      bound2:
-        _class: Expressir::Model::Literals::Integer
-        value: '9'
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Assignment
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
-      expression:
-        _class: Expressir::Model::Expressions::QueryExpression
-        id: remark_query
-        remarks:
-        - rule query scope - rule query
-        aggregate_source:
-          _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      id: WR1
-      remarks:
-      - rule scope - rule where
-      - rule scope - rule where, with prefix
-      - schema scope - rule where
-      - schema scope - rule where, with prefix
-      - universal scope - rule where
-      - universal scope - rule where, with prefix
+        _class: Expressir::Model::DataTypes::Boolean
       expression:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
-    informal_propositions:
-    - _class: Expressir::Model::Declarations::InformalPropositionRule
-      id: IP1
-      remarks:
-      - rule scope - rule informal proposition, with prefix
-      - schema scope - rule informal proposition
-      - schema scope - rule informal proposition, with prefix
-      - universal scope - rule informal proposition
-      - universal scope - rule informal proposition, with prefix
-      remark_items:
-      - _class: Expressir::Model::Declarations::RemarkItem
-        id: IP1
-        remarks:
-        - rule scope - rule informal proposition
-  procedures:
-  - _class: Expressir::Model::Declarations::Procedure
-    id: remark_procedure
-    remarks:
-    - schema scope - procedure
-    - universal scope - procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: remark_parameter
-      remarks:
-      - procedure scope - procedure parameter
-      - schema scope - procedure parameter
-      - universal scope - procedure parameter
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_constant_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: test
       type:
-        _class: Expressir::Model::DataTypes::String
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Constant
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: variable_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_variable_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_shorthand_variable_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: variable_expression_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_variable_expression_function
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Function
+    id: multiple_shorthand_variable_expression_function
+    remarks:
+    - rules
+    untagged_remarks:
+    - text: rules
+      format: tail
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  rules:
+  - _class: Expressir::Model::Declarations::Rule
+    id: empty_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: type_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
     types:
     - _class: Expressir::Model::Declarations::Type
-      id: remark_type
-      remarks:
-      - procedure scope - procedure type
-      - schema scope - procedure type
-      - universal scope - procedure type
+      id: test
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Boolean
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: constant_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: multiple_constant_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Constant
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: variable_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: multiple_variable_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: multiple_shorthand_variable_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: variable_expression_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: multiple_variable_expression_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: multiple_shorthand_variable_expression_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: statement_rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    statements:
+    - _class: Expressir::Model::Statements::Null
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Rule
+    id: where_label_rule
+    remarks:
+    - procedures
+    untagged_remarks:
+    - text: procedures
+      format: tail
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: empty_entity
+      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      id: WR1
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  procedures:
+  - _class: Expressir::Model::Declarations::Procedure
+    id: empty_procedure
+  - _class: Expressir::Model::Declarations::Procedure
+    id: parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_shorthand_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: variable_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_variable_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_variable_parameter2_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_shorthand_variable_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: type_procedure
+    types:
+    - _class: Expressir::Model::Declarations::Type
+      id: test
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: constant_procedure
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_constant_procedure
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Constant
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Procedure
+    id: variable_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_variable_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_shorthand_variable_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+  - _class: Expressir::Model::Declarations::Procedure
+    id: variable_expression_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_variable_expression_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Procedure
+    id: multiple_shorthand_variable_expression_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+  - _class: Expressir::Model::Declarations::Procedure
+    id: statement_procedure
+    statements:
+    - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Procedure
+    id: statements
+    remarks:
+    - statements
+    - simple types
+    untagged_remarks:
+    - text: statements
+      format: tail
+    - text: simple types
+      format: tail
+    procedures:
+    - _class: Expressir::Model::Declarations::Procedure
+      id: alias_simple_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Alias
+        id: test
+        expression:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: alias_group_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Alias
+        id: test
+        expression:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: alias_index_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Alias
+        id: test
+        expression:
+          _class: Expressir::Model::References::IndexReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          index1:
+            _class: Expressir::Model::Literals::Integer
+            value: '1'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: alias_index2_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Alias
+        id: test
+        expression:
+          _class: Expressir::Model::References::IndexReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          index1:
+            _class: Expressir::Model::Literals::Integer
+            value: '1'
+          index2:
+            _class: Expressir::Model::Literals::Integer
+            value: '9'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: alias_attribute_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Alias
+        id: test
+        expression:
+          _class: Expressir::Model::References::AttributeReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          attribute:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: assignment_simple_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Assignment
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: assignment_group_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Assignment
+        ref:
+          _class: Expressir::Model::References::GroupReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          entity:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: assignment_index_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Assignment
+        ref:
+          _class: Expressir::Model::References::IndexReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          index1:
+            _class: Expressir::Model::Literals::Integer
+            value: '1'
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: assignment_index2_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Assignment
+        ref:
+          _class: Expressir::Model::References::IndexReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          index1:
+            _class: Expressir::Model::Literals::Integer
+            value: '1'
+          index2:
+            _class: Expressir::Model::Literals::Integer
+            value: '9'
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: assignment_attribute_reference_statement
+      statements:
+      - _class: Expressir::Model::Statements::Assignment
+        ref:
+          _class: Expressir::Model::References::AttributeReference
+          ref:
+            _class: Expressir::Model::References::SimpleReference
+            id: test
+          attribute:
+            _class: Expressir::Model::References::SimpleReference
+            id: test2
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: case_statement
+      statements:
+      - _class: Expressir::Model::Statements::Case
+        expression:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        actions:
+        - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: case_multiple_statement
+      statements:
+      - _class: Expressir::Model::Statements::Case
+        expression:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        actions:
+        - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: case_multiple_shorthand_statement
+      statements:
+      - _class: Expressir::Model::Statements::Case
+        expression:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        actions:
+        - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: case_otherwise_statement
+      statements:
+      - _class: Expressir::Model::Statements::Case
+        expression:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        actions:
+        - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+        otherwise_statement:
+          _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: compound_statement
+      statements:
+      - _class: Expressir::Model::Statements::Compound
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: escape_statement
+      statements:
+      - _class: Expressir::Model::Statements::Escape
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if2_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if_else_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+        else_statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if2_else_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::Null
+        else_statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if_else2_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+        else_statements:
+        - _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: if2_else2_statement
+      statements:
+      - _class: Expressir::Model::Statements::If
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::Null
+        else_statements:
+        - _class: Expressir::Model::Statements::Null
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: null_statement
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: call_statement
+      statements:
+      - _class: Expressir::Model::Statements::ProcedureCall
+        procedure:
+          _class: Expressir::Model::References::SimpleReference
+          id: empty_procedure
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
+    - _class: Expressir::Model::Declarations::Procedure
+      id: call_parameter_statement
+      statements:
+      - _class: Expressir::Model::Statements::ProcedureCall
+        procedure:
+          _class: Expressir::Model::References::SimpleReference
+          id: empty_procedure
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: call_parameter2_statement
+      statements:
+      - _class: Expressir::Model::Statements::ProcedureCall
+        procedure:
+          _class: Expressir::Model::References::SimpleReference
+          id: empty_procedure
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: call_insert_statement
+      statements:
+      - _class: Expressir::Model::Statements::ProcedureCall
+        procedure:
+          _class: Expressir::Model::References::SimpleReference
+          id: INSERT
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: call_remove_statement
+      statements:
+      - _class: Expressir::Model::Statements::ProcedureCall
+        procedure:
+          _class: Expressir::Model::References::SimpleReference
+          id: REMOVE
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: repeat_statement
+      statements:
+      - _class: Expressir::Model::Statements::Repeat
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: repeat_variable_statement
+      statements:
+      - _class: Expressir::Model::Statements::Repeat
+        id: test
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: repeat_variable_increment_statement
+      statements:
+      - _class: Expressir::Model::Statements::Repeat
+        id: test
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        increment:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: repeat_while_statement
+      statements:
+      - _class: Expressir::Model::Statements::Repeat
+        while_expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: repeat_until_statement
+      statements:
+      - _class: Expressir::Model::Statements::Repeat
+        until_expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        statements:
+        - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Procedure
+      id: return_statement
+      statements:
+      - _class: Expressir::Model::Statements::Return
+    - _class: Expressir::Model::Declarations::Procedure
+      id: return_expression_statement
+      statements:
+      - _class: Expressir::Model::Statements::Return
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Procedure
+      id: skip_statement
+      statements:
+      - _class: Expressir::Model::Statements::Skip
+  - _class: Expressir::Model::Declarations::Procedure
+    id: types
+    remarks:
+    - aggregation types
+    - constructed types
+    - literal expressions
+    untagged_remarks:
+    - text: aggregation types
+      format: tail
+    - text: constructed types
+      format: tail
+    - text: literal expressions
+      format: tail
+    types:
+    - _class: Expressir::Model::Declarations::Type
+      id: binary_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Binary
+    - _class: Expressir::Model::Declarations::Type
+      id: binary_width_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Binary
+        width:
+          _class: Expressir::Model::Literals::Integer
+          value: '3'
+    - _class: Expressir::Model::Declarations::Type
+      id: binary_width_fixed_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Binary
+        width:
+          _class: Expressir::Model::Literals::Integer
+          value: '3'
+        fixed: true
+    - _class: Expressir::Model::Declarations::Type
+      id: boolean_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Type
+      id: integer_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Integer
+    - _class: Expressir::Model::Declarations::Type
+      id: logical_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Logical
+    - _class: Expressir::Model::Declarations::Type
+      id: number_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Number
+    - _class: Expressir::Model::Declarations::Type
+      id: real_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Real
+    - _class: Expressir::Model::Declarations::Type
+      id: real_precision_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Real
+        precision:
+          _class: Expressir::Model::Literals::Integer
+          value: '3'
+    - _class: Expressir::Model::Declarations::Type
+      id: string_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: string_width_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::String
+        width:
+          _class: Expressir::Model::Literals::Integer
+          value: '3'
+    - _class: Expressir::Model::Declarations::Type
+      id: string_width_fixed_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::String
+        width:
+          _class: Expressir::Model::Literals::Integer
+          value: '3'
+        fixed: true
+    - _class: Expressir::Model::Declarations::Type
+      id: array_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Array
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        optional: false
+        unique: false
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: array_optional_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Array
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        optional: true
+        unique: false
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: array_unique_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Array
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        optional: false
+        unique: true
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: array_optional_unique_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Array
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        optional: true
+        unique: true
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: bag_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Bag
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: bag_bound_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Bag
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: list_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::List
+        unique: false
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: list_bound_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::List
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        unique: false
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: list_unique_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::List
+        unique: true
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: list_bound_unique_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::List
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        unique: true
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: set_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Set
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: set_bound_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Set
+        bound1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        bound2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+        base_type:
+          _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::Type
+      id: select_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+    - _class: Expressir::Model::Declarations::Type
+      id: select_extensible_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        extensible: true
+    - _class: Expressir::Model::Declarations::Type
+      id: select_extensible_generic_entity_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        extensible: true
+        generic_entity: true
+    - _class: Expressir::Model::Declarations::Type
+      id: select_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        items:
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+    - _class: Expressir::Model::Declarations::Type
+      id: select_multiple_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        items:
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+    - _class: Expressir::Model::Declarations::Type
+      id: select_based_on_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: select_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
+    - _class: Expressir::Model::Declarations::Type
+      id: select_based_on_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: select_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
+        items:
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+    - _class: Expressir::Model::Declarations::Type
+      id: select_based_on_multiple_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Select
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: select_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
+        items:
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+        - _class: Expressir::Model::References::SimpleReference
+          id: empty_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_extensible_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        extensible: true
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_item_type
       underlying_type:
         _class: Expressir::Model::DataTypes::Enumeration
         items:
         - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: remark_enumeration_item
-          remarks:
-          - procedure scope - procedure enumeration item
-          - procedure scope - procedure enumeration item, on the same level as the
-            type
-          - schema scope - procedure enumeration item
-          - schema scope - procedure enumeration item, on the same level as the type
-          - universal scope - procedure enumeration item
-          - universal scope - procedure enumeration item, on the same level as the
-            type
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: remark_constant
+          id: test
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_multiple_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: test
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: test2
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_based_on_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: enumeration_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_based_on_item_type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: enumeration_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: test
+    - _class: Expressir::Model::Declarations::Type
+      id: enumeration_based_on_multiple_item_type
       remarks:
-      - procedure scope - procedure constant
-      - schema scope - procedure constant
-      - universal scope - procedure constant
+      - generic types
+      untagged_remarks:
+      - text: generic types
+        format: tail
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        based_on:
+          _class: Expressir::Model::References::SimpleReference
+          id: enumeration_type
+          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: test
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: test2
+    functions:
+    - _class: Expressir::Model::Declarations::Function
+      id: generic_type
+      return_type:
+        _class: Expressir::Model::DataTypes::Generic
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Function
+      id: generic_label_type
+      return_type:
+        _class: Expressir::Model::DataTypes::Generic
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Function
+      id: generic_entity_type
+      return_type:
+        _class: Expressir::Model::DataTypes::GenericEntity
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Declarations::Function
+      id: generic_entity_label_type
+      return_type:
+        _class: Expressir::Model::DataTypes::GenericEntity
+      statements:
+      - _class: Expressir::Model::Statements::Null
+  - _class: Expressir::Model::Declarations::Procedure
+    id: expressions
+    remarks:
+    - constant expressions
+    - function expressions
+    - operator expressions
+    - aggregate initializer expressions
+    - function call or entity constructor expressions
+    - reference expressions
+    - interval expressions
+    untagged_remarks:
+    - text: constant expressions
+      format: tail
+    - text: function expressions
+      format: tail
+    - text: operator expressions
+      format: tail
+    - text: aggregate initializer expressions
+      format: tail
+    - text: function call or entity constructor expressions
+      format: tail
+    - text: reference expressions
+      format: tail
+    - text: interval expressions
+      format: tail
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: binary_expression
       type:
-        _class: Expressir::Model::DataTypes::String
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Binary
+        value: "%011110000111100001111000"
+    - _class: Expressir::Model::Declarations::Variable
+      id: integer_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Integer
+        value: '999'
+    - _class: Expressir::Model::Declarations::Variable
+      id: true_logical_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: false_logical_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'FALSE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: unknown_logical_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: UNKNOWN
+    - _class: Expressir::Model::Declarations::Variable
+      id: real_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Real
+        value: '999.999'
+    - _class: Expressir::Model::Declarations::Variable
+      id: simple_string_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
       expression:
         _class: Expressir::Model::Literals::String
         value: xxx
-    variables:
     - _class: Expressir::Model::Declarations::Variable
-      id: remark_variable
-      remarks:
-      - procedure scope - procedure variable
-      - schema scope - procedure variable
-      - universal scope - procedure variable
+      id: utf8_simple_string_expression
       type:
-        _class: Expressir::Model::DataTypes::String
-    statements:
-    - _class: Expressir::Model::Statements::Alias
-      id: remark_alias
-      remarks:
-      - procedure alias scope - procedure alias
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::String
+        value: 'UTF8 test: Příliš žluťoučký kůň úpěl ďábelské ódy.'
+    - _class: Expressir::Model::Declarations::Variable
+      id: encoded_string_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::String
+        value: '000000780000007800000078'
+        encoded: true
+    - _class: Expressir::Model::Declarations::Variable
+      id: const_e_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
       expression:
         _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Repeat
-      id: remark_repeat
-      remarks:
-      - procedure repeat scope - procedure repeat
-      bound1:
-        _class: Expressir::Model::Literals::Integer
-        value: '1'
-      bound2:
-        _class: Expressir::Model::Literals::Integer
-        value: '9'
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Statements::Assignment
-      ref:
+        id: CONST_E
+    - _class: Expressir::Model::Declarations::Variable
+      id: indeterminate_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
         _class: Expressir::Model::References::SimpleReference
-        id: remark_variable
-        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
+        id: "?"
+    - _class: Expressir::Model::Declarations::Variable
+      id: pi_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: PI
+    - _class: Expressir::Model::Declarations::Variable
+      id: self_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: SELF
+    - _class: Expressir::Model::Declarations::Variable
+      id: abs_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ABS
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: acos_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ACOS
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: asin_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ASIN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: atan_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ATAN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: blength_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: BLENGTH
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: cos_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: COS
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: exists_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: EXISTS
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: exp_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: EXP
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: format_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: FORMAT
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: hibound_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: HIBOUND
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: hiindex_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: HIINDEX
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: length_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LENGTH
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lobound_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LOBOUND
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: loindex_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LOINDEX
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: log_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LOG
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: log2_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LOG2
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: log10_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: LOG10
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: nvl_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: NVL
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: odd_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ODD
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: rolesof_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: ROLESOF
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: sin_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: SIN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: sizeof_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: SIZEOF
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: sqrt_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: SQRT
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: tan_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: TAN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: typeof_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: TYPEOF
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: usedin_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: USEDIN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: value_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: VALUE
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: value_in_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: VALUE_IN
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: value_unique_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: VALUE_UNIQUE
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: plus_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: PLUS
+        operand:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+    - _class: Expressir::Model::Declarations::Variable
+      id: plus_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: PLUS
+        operand:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: minus_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: MINUS
+        operand:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+    - _class: Expressir::Model::Declarations::Variable
+      id: minus_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: MINUS
+        operand:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: ADDITION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: subtraction_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: SUBTRACTION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: multiplication_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: MULTIPLICATION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: real_division_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: REAL_DIVISION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: integer_division_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: INTEGER_DIVISION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: modulo_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: MODULO
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: exponentiation_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Integer
+        value: '4'
+    - _class: Expressir::Model::Declarations::Variable
+      id: addition_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: ADDITION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+    - _class: Expressir::Model::Declarations::Variable
+      id: subtraction_subtraction_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: SUBTRACTION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: SUBTRACTION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+    - _class: Expressir::Model::Declarations::Variable
+      id: addition_subtraction_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: SUBTRACTION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+    - _class: Expressir::Model::Declarations::Variable
+      id: subtraction_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: ADDITION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: SUBTRACTION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+    - _class: Expressir::Model::Declarations::Variable
+      id: addition_multiplication_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: ADDITION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '8'
+        operand2:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: MULTIPLICATION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: multiplication_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: ADDITION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: MULTIPLICATION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '8'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: parenthesis_addition_multiplication_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: MULTIPLICATION
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '8'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: multiplication_parenthesis_addition_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: MULTIPLICATION
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '8'
+        operand2:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: equal_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: not_equal_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: NOT_EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: instance_equal_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: INSTANCE_EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: instance_not_equal_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: INSTANCE_NOT_EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lt_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: LESS_THAN
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: gt_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: GREATER_THAN
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lte_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: LESS_THAN_OR_EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: gte_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: GREATER_THAN_OR_EQUAL
+        operand1:
+          _class: Expressir::Model::Literals::Integer
+          value: '4'
+        operand2:
+          _class: Expressir::Model::Literals::Integer
+          value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: not_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: NOT
+        operand:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: not_or_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::UnaryExpression
+        operator: NOT
+        operand:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: OR
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: or_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: OR
+        operand1:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'FALSE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: and_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'FALSE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: or_or_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: OR
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: OR
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: and_and_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: AND
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: or_and_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: OR
+        operand1:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        operand2:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: AND
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: and_or_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: OR
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: AND
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: parenthesis_or_and_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: OR
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+        operand2:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: and_parenthesis_or_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: AND
+        operand1:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        operand2:
+          _class: Expressir::Model::Expressions::BinaryExpression
+          operator: OR
+          operand1:
+            _class: Expressir::Model::Literals::Logical
+            value: 'FALSE'
+          operand2:
+            _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: combine_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: COMBINE
+        operand1:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        operand2:
+          _class: Expressir::Model::References::SimpleReference
+          id: test2
+    - _class: Expressir::Model::Declarations::Variable
+      id: in_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: IN
+        operand1:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+        operand2:
+          _class: Expressir::Model::Expressions::AggregateInitializer
+          items:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: like_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::BinaryExpression
+        operator: LIKE
+        operand1:
+          _class: Expressir::Model::Literals::String
+          value: xxx
+        operand2:
+          _class: Expressir::Model::Literals::String
+          value: xxx
+    - _class: Expressir::Model::Declarations::Variable
+      id: aggregate_initializer_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::AggregateInitializer
+        items:
+        - _class: Expressir::Model::Literals::Integer
+          value: '4'
+    - _class: Expressir::Model::Declarations::Variable
+      id: repeated_aggregate_initializer_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::AggregateInitializer
+        items:
+        - _class: Expressir::Model::Literals::Integer
+          value: '4'
+    - _class: Expressir::Model::Declarations::Variable
+      id: complex_aggregate_initializer_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::AggregateInitializer
+        items:
+        - _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: complex_repeated_aggregate_initializer_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::AggregateInitializer
+        items:
+        - _class: Expressir::Model::Expressions::BinaryExpression
+          operator: ADDITION
+          operand1:
+            _class: Expressir::Model::Literals::Integer
+            value: '4'
+          operand2:
+            _class: Expressir::Model::Literals::Integer
+            value: '2'
+    - _class: Expressir::Model::Declarations::Variable
+      id: call_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::FunctionCall
+        function:
+          _class: Expressir::Model::References::SimpleReference
+          id: parameter_function
+          base_path: spec/syntax/syntax.exp.syntax_schema.parameter_function
+        parameters:
+        - _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: simple_reference_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: test
+    - _class: Expressir::Model::Declarations::Variable
+      id: group_reference_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::GroupReference
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        entity:
+          _class: Expressir::Model::References::SimpleReference
+          id: test2
+    - _class: Expressir::Model::Declarations::Variable
+      id: index_reference_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::IndexReference
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        index1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+    - _class: Expressir::Model::Declarations::Variable
+      id: index2_reference_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::IndexReference
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        index1:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        index2:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+    - _class: Expressir::Model::Declarations::Variable
+      id: attribute_reference_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::References::AttributeReference
+        ref:
+          _class: Expressir::Model::References::SimpleReference
+          id: test
+        attribute:
+          _class: Expressir::Model::References::SimpleReference
+          id: test2
+    - _class: Expressir::Model::Declarations::Variable
+      id: lt_lt_interval_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::Interval
+        low:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        operator1: LESS_THAN
+        item:
+          _class: Expressir::Model::Literals::Integer
+          value: '5'
+        operator2: LESS_THAN
+        high:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lte_lt_interval_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::Interval
+        low:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        operator1: LESS_THAN_OR_EQUAL
+        item:
+          _class: Expressir::Model::Literals::Integer
+          value: '5'
+        operator2: LESS_THAN
+        high:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lt_lte_interval_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::Interval
+        low:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        operator1: LESS_THAN
+        item:
+          _class: Expressir::Model::Literals::Integer
+          value: '5'
+        operator2: LESS_THAN_OR_EQUAL
+        high:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+    - _class: Expressir::Model::Declarations::Variable
+      id: lte_lte_interval_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Expressions::Interval
+        low:
+          _class: Expressir::Model::Literals::Integer
+          value: '1'
+        operator1: LESS_THAN_OR_EQUAL
+        item:
+          _class: Expressir::Model::Literals::Integer
+          value: '5'
+        operator2: LESS_THAN_OR_EQUAL
+        high:
+          _class: Expressir::Model::Literals::Integer
+          value: '9'
+    - _class: Expressir::Model::Declarations::Variable
+      id: query_expression
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
       expression:
         _class: Expressir::Model::Expressions::QueryExpression
-        id: remark_query
-        remarks:
-        - procedure query scope - procedure query
+        id: test
         aggregate_source:
           _class: Expressir::Model::References::SimpleReference
-          id: remark_variable
-          base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
+          id: test2
         expression:
           _class: Expressir::Model::Literals::Logical
           value: 'TRUE'

--- a/spec/syntax/syntax_formatted.exp
+++ b/spec/syntax/syntax_formatted.exp
@@ -19,7 +19,6 @@ REFERENCE FROM contract_schema
 
     -- interfaces
     -- constants
-    -- types
 
 
 CONSTANT
@@ -267,7 +266,8 @@ FUNCTION multiple_parameter_function(test : BOOLEAN;
   ;
 END_FUNCTION;
 
-FUNCTION multiple_shorthand_parameter_function : BOOLEAN;
+FUNCTION multiple_shorthand_parameter_function(test : BOOLEAN;
+                                               test2 : BOOLEAN) : BOOLEAN;
   ;
 END_FUNCTION;
 
@@ -308,6 +308,10 @@ FUNCTION multiple_variable_function : BOOLEAN;
 END_FUNCTION;
 
 FUNCTION multiple_shorthand_variable_function : BOOLEAN;
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
   ;
 END_FUNCTION;
 
@@ -327,6 +331,10 @@ FUNCTION multiple_variable_expression_function : BOOLEAN;
 END_FUNCTION;
 
 FUNCTION multiple_shorthand_variable_expression_function : BOOLEAN;
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
   ;
 END_FUNCTION;
 
@@ -377,6 +385,10 @@ WHERE
 END_RULE;
 
 RULE multiple_shorthand_variable_rule FOR (empty_entity);
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
 WHERE
   TRUE;
 END_RULE;
@@ -399,6 +411,10 @@ WHERE
 END_RULE;
 
 RULE multiple_shorthand_variable_expression_rule FOR (empty_entity);
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
 WHERE
   TRUE;
 END_RULE;
@@ -419,22 +435,27 @@ END_PROCEDURE;
 PROCEDURE parameter_procedure(test : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_parameter_procedure;
+PROCEDURE multiple_parameter_procedure(test : BOOLEAN;
+                                       test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_shorthand_parameter_procedure;
+PROCEDURE multiple_shorthand_parameter_procedure(test : BOOLEAN;
+                                                 test2 : BOOLEAN);
 END_PROCEDURE;
 
 PROCEDURE variable_parameter_procedure(VAR test : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_variable_parameter_procedure;
+PROCEDURE multiple_variable_parameter_procedure(VAR test : BOOLEAN;
+                                                test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_variable_parameter2_procedure;
+PROCEDURE multiple_variable_parameter2_procedure(test : BOOLEAN;
+                                                 VAR test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_shorthand_variable_parameter_procedure;
+PROCEDURE multiple_shorthand_variable_parameter_procedure(VAR test : BOOLEAN;
+                                                          VAR test2 : BOOLEAN);
 END_PROCEDURE;
 
 PROCEDURE type_procedure;
@@ -469,6 +490,10 @@ PROCEDURE multiple_variable_procedure;
 END_PROCEDURE;
 
 PROCEDURE multiple_shorthand_variable_procedure;
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
 END_PROCEDURE;
 
 PROCEDURE variable_expression_procedure;
@@ -485,6 +510,10 @@ PROCEDURE multiple_variable_expression_procedure;
 END_PROCEDURE;
 
 PROCEDURE multiple_shorthand_variable_expression_procedure;
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
 END_PROCEDURE;
 
 PROCEDURE statement_procedure;
@@ -534,28 +563,30 @@ PROCEDURE statements;
   END_PROCEDURE;
   PROCEDURE case_statement;
     CASE test OF
-     :
-    
+    TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
     CASE test OF
-     :
-    
-     :
-    
+    TRUE :
+      ;
+    TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
     CASE test OF
-     :
-    
+    TRUE, TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
     CASE test OF
-     :
-    
+    TRUE :
+      ;
+    OTHERWISE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE compound_statement;
@@ -712,14 +743,11 @@ PROCEDURE types;
   END_TYPE;
   TYPE set_bound_type = SET [1:9] OF STRING;
   END_TYPE;
-  TYPE select_type = SELECT
-    ();
+  TYPE select_type = SELECT;
   END_TYPE;
-  TYPE select_extensible_type = EXTENSIBLE SELECT
-    ();
+  TYPE select_extensible_type = EXTENSIBLE SELECT;
   END_TYPE;
-  TYPE select_extensible_generic_entity_type = EXTENSIBLE GENERIC_ENTITY SELECT
-    ();
+  TYPE select_extensible_generic_entity_type = EXTENSIBLE GENERIC_ENTITY SELECT;
   END_TYPE;
   TYPE select_item_type = SELECT
     (empty_type);
@@ -773,7 +801,7 @@ END_PROCEDURE;
 
 PROCEDURE expressions;
   LOCAL
-    binary_expression : BOOLEAN := %%011110000111100001111000;
+    binary_expression : BOOLEAN := %011110000111100001111000;
     integer_expression : BOOLEAN := 999;
     true_logical_expression : BOOLEAN := TRUE;
     false_logical_expression : BOOLEAN := FALSE;
@@ -826,10 +854,10 @@ PROCEDURE expressions;
     integer_division_expression : BOOLEAN := 4 DIV 2;
     modulo_expression : BOOLEAN := 4 MOD 2;
     exponentiation_expression : BOOLEAN := 4;
-    addition_addition_expression : BOOLEAN := 4 + 2 + 1;
-    subtraction_subtraction_expression : BOOLEAN := 4 - 2 - 1;
-    addition_subtraction_expression : BOOLEAN := 4 + 2 - 1;
-    subtraction_addition_expression : BOOLEAN := 4 - 2 + 1;
+    addition_addition_expression : BOOLEAN := (4 + 2) + 1;
+    subtraction_subtraction_expression : BOOLEAN := (4 - 2) - 1;
+    addition_subtraction_expression : BOOLEAN := (4 + 2) - 1;
+    subtraction_addition_expression : BOOLEAN := (4 - 2) + 1;
     addition_multiplication_expression : BOOLEAN := 8 + 4 * 2;
     multiplication_addition_expression : BOOLEAN := 8 * 4 + 2;
     parenthesis_addition_multiplication_expression : BOOLEAN := (8 + 4) * 2;
@@ -846,8 +874,8 @@ PROCEDURE expressions;
     not_or_expression : BOOLEAN := NOT (TRUE OR FALSE);
     or_expression : BOOLEAN := TRUE OR FALSE;
     and_expression : BOOLEAN := TRUE AND FALSE;
-    or_or_expression : BOOLEAN := TRUE OR FALSE OR TRUE;
-    and_and_expression : BOOLEAN := TRUE AND FALSE AND TRUE;
+    or_or_expression : BOOLEAN := (TRUE OR FALSE) OR TRUE;
+    and_and_expression : BOOLEAN := (TRUE AND FALSE) AND TRUE;
     or_and_expression : BOOLEAN := TRUE OR FALSE AND TRUE;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;

--- a/spec/syntax/syntax_hyperlink_formatted.exp
+++ b/spec/syntax/syntax_hyperlink_formatted.exp
@@ -19,7 +19,6 @@ REFERENCE FROM contract_schema
 
     -- interfaces
     -- constants
-    -- types
 
 
 CONSTANT
@@ -267,7 +266,8 @@ FUNCTION multiple_parameter_function(test : BOOLEAN;
   ;
 END_FUNCTION;
 
-FUNCTION multiple_shorthand_parameter_function : BOOLEAN;
+FUNCTION multiple_shorthand_parameter_function(test : BOOLEAN;
+                                               test2 : BOOLEAN) : BOOLEAN;
   ;
 END_FUNCTION;
 
@@ -308,6 +308,10 @@ FUNCTION multiple_variable_function : BOOLEAN;
 END_FUNCTION;
 
 FUNCTION multiple_shorthand_variable_function : BOOLEAN;
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
   ;
 END_FUNCTION;
 
@@ -327,6 +331,10 @@ FUNCTION multiple_variable_expression_function : BOOLEAN;
 END_FUNCTION;
 
 FUNCTION multiple_shorthand_variable_expression_function : BOOLEAN;
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
   ;
 END_FUNCTION;
 
@@ -377,6 +385,10 @@ WHERE
 END_RULE;
 
 RULE multiple_shorthand_variable_rule FOR (empty_entity);
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
 WHERE
   TRUE;
 END_RULE;
@@ -399,6 +411,10 @@ WHERE
 END_RULE;
 
 RULE multiple_shorthand_variable_expression_rule FOR (empty_entity);
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
 WHERE
   TRUE;
 END_RULE;
@@ -419,22 +435,27 @@ END_PROCEDURE;
 PROCEDURE parameter_procedure(test : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_parameter_procedure;
+PROCEDURE multiple_parameter_procedure(test : BOOLEAN;
+                                       test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_shorthand_parameter_procedure;
+PROCEDURE multiple_shorthand_parameter_procedure(test : BOOLEAN;
+                                                 test2 : BOOLEAN);
 END_PROCEDURE;
 
 PROCEDURE variable_parameter_procedure(VAR test : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_variable_parameter_procedure;
+PROCEDURE multiple_variable_parameter_procedure(VAR test : BOOLEAN;
+                                                test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_variable_parameter2_procedure;
+PROCEDURE multiple_variable_parameter2_procedure(test : BOOLEAN;
+                                                 VAR test2 : BOOLEAN);
 END_PROCEDURE;
 
-PROCEDURE multiple_shorthand_variable_parameter_procedure;
+PROCEDURE multiple_shorthand_variable_parameter_procedure(VAR test : BOOLEAN;
+                                                          VAR test2 : BOOLEAN);
 END_PROCEDURE;
 
 PROCEDURE type_procedure;
@@ -469,6 +490,10 @@ PROCEDURE multiple_variable_procedure;
 END_PROCEDURE;
 
 PROCEDURE multiple_shorthand_variable_procedure;
+  LOCAL
+    test : BOOLEAN;
+    test2 : BOOLEAN;
+  END_LOCAL;
 END_PROCEDURE;
 
 PROCEDURE variable_expression_procedure;
@@ -485,6 +510,10 @@ PROCEDURE multiple_variable_expression_procedure;
 END_PROCEDURE;
 
 PROCEDURE multiple_shorthand_variable_expression_procedure;
+  LOCAL
+    test : BOOLEAN := TRUE;
+    test2 : BOOLEAN := TRUE;
+  END_LOCAL;
 END_PROCEDURE;
 
 PROCEDURE statement_procedure;
@@ -534,28 +563,30 @@ PROCEDURE statements;
   END_PROCEDURE;
   PROCEDURE case_statement;
     CASE test OF
-     :
-    
+    TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_statement;
     CASE test OF
-     :
-    
-     :
-    
+    TRUE :
+      ;
+    TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_multiple_shorthand_statement;
     CASE test OF
-     :
-    
+    TRUE, TRUE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE case_otherwise_statement;
     CASE test OF
-     :
-    
+    TRUE :
+      ;
+    OTHERWISE :
+      ;
     END_CASE;
   END_PROCEDURE;
   PROCEDURE compound_statement;
@@ -712,14 +743,11 @@ PROCEDURE types;
   END_TYPE;
   TYPE set_bound_type = SET [1:9] OF STRING;
   END_TYPE;
-  TYPE select_type = SELECT
-    ();
+  TYPE select_type = SELECT;
   END_TYPE;
-  TYPE select_extensible_type = EXTENSIBLE SELECT
-    ();
+  TYPE select_extensible_type = EXTENSIBLE SELECT;
   END_TYPE;
-  TYPE select_extensible_generic_entity_type = EXTENSIBLE GENERIC_ENTITY SELECT
-    ();
+  TYPE select_extensible_generic_entity_type = EXTENSIBLE GENERIC_ENTITY SELECT;
   END_TYPE;
   TYPE select_item_type = SELECT
     (empty_type);
@@ -773,7 +801,7 @@ END_PROCEDURE;
 
 PROCEDURE expressions;
   LOCAL
-    binary_expression : BOOLEAN := %%011110000111100001111000;
+    binary_expression : BOOLEAN := %011110000111100001111000;
     integer_expression : BOOLEAN := 999;
     true_logical_expression : BOOLEAN := TRUE;
     false_logical_expression : BOOLEAN := FALSE;
@@ -826,10 +854,10 @@ PROCEDURE expressions;
     integer_division_expression : BOOLEAN := 4 DIV 2;
     modulo_expression : BOOLEAN := 4 MOD 2;
     exponentiation_expression : BOOLEAN := 4;
-    addition_addition_expression : BOOLEAN := 4 + 2 + 1;
-    subtraction_subtraction_expression : BOOLEAN := 4 - 2 - 1;
-    addition_subtraction_expression : BOOLEAN := 4 + 2 - 1;
-    subtraction_addition_expression : BOOLEAN := 4 - 2 + 1;
+    addition_addition_expression : BOOLEAN := (4 + 2) + 1;
+    subtraction_subtraction_expression : BOOLEAN := (4 - 2) - 1;
+    addition_subtraction_expression : BOOLEAN := (4 + 2) - 1;
+    subtraction_addition_expression : BOOLEAN := (4 - 2) + 1;
     addition_multiplication_expression : BOOLEAN := 8 + 4 * 2;
     multiplication_addition_expression : BOOLEAN := 8 * 4 + 2;
     parenthesis_addition_multiplication_expression : BOOLEAN := (8 + 4) * 2;
@@ -846,8 +874,8 @@ PROCEDURE expressions;
     not_or_expression : BOOLEAN := NOT (TRUE OR FALSE);
     or_expression : BOOLEAN := TRUE OR FALSE;
     and_expression : BOOLEAN := TRUE AND FALSE;
-    or_or_expression : BOOLEAN := TRUE OR FALSE OR TRUE;
-    and_and_expression : BOOLEAN := TRUE AND FALSE AND TRUE;
+    or_or_expression : BOOLEAN := (TRUE OR FALSE) OR TRUE;
+    and_and_expression : BOOLEAN := (TRUE AND FALSE) AND TRUE;
     or_and_expression : BOOLEAN := TRUE OR FALSE AND TRUE;
     and_or_expression : BOOLEAN := TRUE AND FALSE OR TRUE;
     parenthesis_or_and_expression : BOOLEAN := (TRUE OR FALSE) AND TRUE;

--- a/spec/syntax/syntax_parser.yaml
+++ b/spec/syntax/syntax_parser.yaml
@@ -8,15 +8,12 @@ schemas:
   - interfaces
   - constants
   - types
-  - rules
   untagged_remarks:
   - text: interfaces
     format: tail
   - text: constants
     format: tail
   - text: types
-    format: tail
-  - text: rules
     format: tail
   file: spec/syntax/syntax.exp
   version:
@@ -957,6 +954,15 @@ schemas:
     - _class: Expressir::Model::Statements::Null
   - _class: Expressir::Model::Declarations::Function
     id: multiple_shorthand_parameter_function
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
     return_type:
       _class: Expressir::Model::DataTypes::Boolean
     statements:
@@ -1037,6 +1043,15 @@ schemas:
     id: multiple_shorthand_variable_function
     return_type:
       _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
     statements:
     - _class: Expressir::Model::Statements::Null
   - _class: Expressir::Model::Declarations::Function
@@ -1076,8 +1091,28 @@ schemas:
     - _class: Expressir::Model::Statements::Null
   - _class: Expressir::Model::Declarations::Function
     id: multiple_shorthand_variable_expression_function
+    remarks:
+    - rules
+    untagged_remarks:
+    - text: rules
+      format: tail
     return_type:
       _class: Expressir::Model::DataTypes::Boolean
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
     statements:
     - _class: Expressir::Model::Statements::Null
   rules:
@@ -1195,6 +1230,15 @@ schemas:
     - _class: Expressir::Model::References::SimpleReference
       id: empty_entity
       base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
       expression:
@@ -1251,6 +1295,21 @@ schemas:
     - _class: Expressir::Model::References::SimpleReference
       id: empty_entity
       base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
       expression:
@@ -1298,8 +1357,26 @@ schemas:
         _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_shorthand_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: variable_parameter_procedure
     parameters:
@@ -1310,10 +1387,41 @@ schemas:
         _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_variable_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_variable_parameter2_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_shorthand_variable_parameter_procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Parameter
+      id: test2
+      var: true
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: type_procedure
     types:
@@ -1368,6 +1476,15 @@ schemas:
         _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_shorthand_variable_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
   - _class: Expressir::Model::Declarations::Procedure
     id: variable_expression_procedure
     variables:
@@ -1397,6 +1514,21 @@ schemas:
         value: 'TRUE'
   - _class: Expressir::Model::Declarations::Procedure
     id: multiple_shorthand_variable_expression_procedure
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: test
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    - _class: Expressir::Model::Declarations::Variable
+      id: test2
+      type:
+        _class: Expressir::Model::DataTypes::Boolean
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
   - _class: Expressir::Model::Declarations::Procedure
     id: statement_procedure
     statements:
@@ -1567,6 +1699,11 @@ schemas:
           id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Declarations::Procedure
       id: case_multiple_statement
       statements:
@@ -1576,7 +1713,17 @@ schemas:
           id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
         - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Declarations::Procedure
       id: case_multiple_shorthand_statement
       statements:
@@ -1586,6 +1733,13 @@ schemas:
           id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Declarations::Procedure
       id: case_otherwise_statement
       statements:
@@ -1595,6 +1749,13 @@ schemas:
           id: test
         actions:
         - _class: Expressir::Model::Statements::CaseAction
+          labels:
+          - _class: Expressir::Model::Literals::Logical
+            value: 'TRUE'
+          statement:
+            _class: Expressir::Model::Statements::Null
+        otherwise_statement:
+          _class: Expressir::Model::Statements::Null
     - _class: Expressir::Model::Declarations::Procedure
       id: compound_statement
       statements:


### PR DESCRIPTION
## Summary

Fixes #300 — `expressir format` now produces output that can be re-parsed and produces the same model (structural content is stable across format iterations).

## Root Cause

The formatter was outputting `NOT {interval}` which is ambiguous in EXPRESS — the parser sees `NOT` followed by `{` and cannot match it as an interval expression. The original code wraps intervals in parens: `NOT ({interval})`.

## Changes

### Formatter fixes
- **Interval + unary expression**: Wrap interval operands in parens when inside NOT
- **Binary expression precedence**: Use >= for same-precedence parenthesization
- **AGGREGATE OF**: Format with OF type when base_type is present
- **Empty SELECT**: Handle SELECT types with no items
- **Binary literals**: Value already includes % prefix

### Builder fixes
- **Shorthand variables**: Fix double-wrapping of variable_id keys
- **Procedure parameters**: Same fix for formal parameters and procedure head parameters
- **CASE statements**: Proper case label and otherwise_statement handling
- **AGGREGATE OF**: Add builder support
- **Type builder**: Replace hash+define_method with explicit methods to fix autoload ordering
- **Registry**: Remove all send calls, remove duplicate registrations

### Model fixes
- Remove HasWhereRules from Function/Procedure (EXPRESS spec compliance)
- Harden remark_attacher to use safe_get_collection for where_rules

### Tests
- Add formatter_roundtrip_spec.rb with 10 test cases covering all fixed bugs
- Regenerate YAML and .exp fixtures to match improved builder output

## Verification

- syntax.exp: roundtrips with structural content identical
- mathematical_functions_schema.exp (15K+ lines): roundtrips with structural content identical
- 103 specs pass, 0 failures
- Rubocop clean on all changed files
