### PR TITLE
fix: grant contents:write for reusable rake workflow

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -3,7 +3,7 @@
 name: rake
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -200,7 +200,7 @@ module Expressir
         self.untagged_remarks ||= []
         return unless remark_info.is_a?(RemarkInfo)
 
-        self.untagged_remarks << remark_info
+        untagged_remarks << remark_info
       end
 
       private

--- a/spec/syntax/remark_parser.yaml
+++ b/spec/syntax/remark_parser.yaml
@@ -1,3592 +1,485 @@
 ---
 _class: Expressir::Model::ExpFile
-path: spec/syntax/syntax.exp
+path: spec/syntax/remark.exp
 schemas:
 - _class: Expressir::Model::Declarations::Schema
-  id: syntax_schema
+  id: remark_schema
   remarks:
-  - interfaces
-  - constants
-  - types
-  untagged_remarks:
-  - text: interfaces
-    format: tail
-  - text: constants
-    format: tail
-  - text: types
-    format: tail
-  file: spec/syntax/syntax.exp
-  version:
-    _class: Expressir::Model::Declarations::SchemaVersion
-    value: "{ISO standard 10303 part(41) object(1) version(8)}"
-    items:
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      name: ISO
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      name: standard
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      value: '10303'
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      name: part
-      value: '41'
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      name: object
-      value: '1'
-    - _class: Expressir::Model::Declarations::SchemaVersionItem
-      name: version
-      value: '8'
-  interfaces:
-  - _class: Expressir::Model::Declarations::Interface
-    kind: USE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-  - _class: Expressir::Model::Declarations::Interface
-    kind: USE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-  - _class: Expressir::Model::Declarations::Interface
-    kind: USE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract2
-  - _class: Expressir::Model::Declarations::Interface
-    kind: USE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-      id: contract2
-  - _class: Expressir::Model::Declarations::Interface
-    kind: REFERENCE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-  - _class: Expressir::Model::Declarations::Interface
-    kind: REFERENCE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-  - _class: Expressir::Model::Declarations::Interface
-    kind: REFERENCE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract2
-  - _class: Expressir::Model::Declarations::Interface
-    kind: REFERENCE
-    schema:
-      _class: Expressir::Model::References::SimpleReference
-      id: contract_schema
-    items:
-    - _class: Expressir::Model::Declarations::InterfaceItem
-      ref:
-        _class: Expressir::Model::References::SimpleReference
-        id: contract
-      id: contract2
+  - |-
+    Any character within the EXPRESS character set may occur between the start and end of
+    an embedded remark including the newline character; therefore, embedded remarks can span
+    several physical lines.
+  - The tail remark is written at the end of a physical line.
+  - 'UTF8 test: Příliš žluťoučký kůň úpěl ďábelské ódy.'
+  - universal scope - schema before
+  - universal scope - schema
+  remark_items:
+  - _class: Expressir::Model::Declarations::RemarkItem
+    id: remark_item
+    remarks:
+    - schema scope - schema remark item
+    - universal scope - schema remark item
+  file: spec/syntax/remark.exp
   constants:
   - _class: Expressir::Model::Declarations::Constant
-    id: empty_constant
+    id: remark_constant
+    remarks:
+    - schema scope - constant
+    - universal scope - constant
     type:
-      _class: Expressir::Model::DataTypes::Boolean
+      _class: Expressir::Model::DataTypes::String
     expression:
-      _class: Expressir::Model::Literals::Logical
-      value: 'TRUE'
+      _class: Expressir::Model::Literals::String
+      value: xxx
   types:
   - _class: Expressir::Model::Declarations::Type
-    id: empty_type
-    underlying_type:
-      _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Type
-    id: where_type
-    underlying_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Type
-    id: where_label_type
+    id: remark_type
     remarks:
-    - entities
-    untagged_remarks:
-    - text: entities
-      format: tail
+    - schema scope - type
+    - universal scope - type
     underlying_type:
-      _class: Expressir::Model::DataTypes::Boolean
+      _class: Expressir::Model::DataTypes::Enumeration
+      items:
+      - _class: Expressir::Model::DataTypes::EnumerationItem
+        id: remark_enumeration_item
+        remarks:
+        - schema scope - enumeration item
+        - schema scope - enumeration item, on the same level as the type
+        - universal scope - enumeration item
+        - universal scope - enumeration item, on the same level as the type
     where_rules:
     - _class: Expressir::Model::Declarations::WhereRule
       id: WR1
+      remarks:
+      - type scope - type where
+      - type scope - type where, with prefix
+      - schema scope - type where
+      - schema scope - type where, with prefix
+      - universal scope - type where
+      - universal scope - type where, with prefix
       expression:
         _class: Expressir::Model::Literals::Logical
         value: 'TRUE'
+    informal_propositions:
+    - _class: Expressir::Model::Declarations::InformalPropositionRule
+      id: IP1
+      remarks:
+      - type scope - type informal proposition, with prefix
+      - schema scope - type informal proposition
+      - schema scope - type informal proposition, with prefix
+      - universal scope - type informal proposition
+      - universal scope - type informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - type scope - type informal proposition
   entities:
   - _class: Expressir::Model::Declarations::Entity
-    id: empty_entity
-  - _class: Expressir::Model::Declarations::Entity
-    id: abstract_entity
-    abstract: true
-  - _class: Expressir::Model::Declarations::Entity
-    id: abstract_supertype_entity
-    abstract: true
-  - _class: Expressir::Model::Declarations::Entity
-    id: abstract_supertype_constraint_entity
-    abstract: true
-    supertype_expression:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-  - _class: Expressir::Model::Declarations::Entity
-    id: supertype_constraint_entity
-    supertype_expression:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-  - _class: Expressir::Model::Declarations::Entity
-    id: subtype_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-  - _class: Expressir::Model::Declarations::Entity
-    id: supertype_constraint_subtype_entity
-    supertype_expression:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_optional_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      optional: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_multiple_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test2
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_multiple_shorthand_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test2
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_redeclared_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: attribute_redeclared_renamed_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test2
-      kind: EXPLICIT
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Entity
-    id: derived_attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::DerivedAttribute
-      id: test
-      kind: DERIVED
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Entity
-    id: derived_attribute_redeclared_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::DerivedAttribute
-      id: test
-      kind: DERIVED
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Entity
-    id: derived_attribute_redeclared_renamed_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::DerivedAttribute
-      id: test2
-      kind: DERIVED
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::References::SimpleReference
-        id: attribute_entity
-        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_entity_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::References::SimpleReference
-        id: attribute_entity
-        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_set_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::DataTypes::Set
-        base_type:
-          _class: Expressir::Model::References::SimpleReference
-          id: attribute_entity
-          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_set_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_set_bound_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::DataTypes::Set
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        base_type:
-          _class: Expressir::Model::References::SimpleReference
-          id: attribute_entity
-          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_set_bound_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_bag_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::DataTypes::Bag
-        base_type:
-          _class: Expressir::Model::References::SimpleReference
-          id: attribute_entity
-          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_bag_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_bag_bound_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      type:
-        _class: Expressir::Model::DataTypes::Bag
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        base_type:
-          _class: Expressir::Model::References::SimpleReference
-          id: attribute_entity
-          base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_bag_bound_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_redeclared_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test
-      kind: INVERSE
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::References::SimpleReference
-        id: attribute_entity
-        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.inverse_attribute_redeclared_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: inverse_attribute_redeclared_renamed_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::InverseAttribute
-      id: test2
-      kind: INVERSE
-      supertype_attribute:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-      type:
-        _class: Expressir::Model::References::SimpleReference
-        id: attribute_entity
-        base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: test
-  - _class: Expressir::Model::Declarations::Entity
-    id: unique_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    unique_rules:
-    - _class: Expressir::Model::Declarations::UniqueRule
-      attributes:
-      - _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.unique_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: unique_label_entity
-    attributes:
-    - _class: Expressir::Model::Declarations::Attribute
-      id: test
-      kind: EXPLICIT
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    unique_rules:
-    - _class: Expressir::Model::Declarations::UniqueRule
-      id: UR1
-      attributes:
-      - _class: Expressir::Model::References::SimpleReference
-        id: test
-        base_path: spec/syntax/syntax.exp.syntax_schema.unique_label_entity.test
-  - _class: Expressir::Model::Declarations::Entity
-    id: unique_redeclared_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    unique_rules:
-    - _class: Expressir::Model::Declarations::UniqueRule
-      attributes:
-      - _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-  - _class: Expressir::Model::Declarations::Entity
-    id: unique_label_redeclared_entity
-    subtype_of:
-    - _class: Expressir::Model::References::SimpleReference
-      id: attribute_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-    unique_rules:
-    - _class: Expressir::Model::Declarations::UniqueRule
-      id: UR1
-      attributes:
-      - _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: SELF
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: attribute_entity
-            base_path: spec/syntax/syntax.exp.syntax_schema.attribute_entity
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-  - _class: Expressir::Model::Declarations::Entity
-    id: where_entity
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Entity
-    id: where_label_entity
+    id: remark_entity
     remarks:
-    - subtype constraints
-    untagged_remarks:
-    - text: subtype constraints
-      format: tail
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      id: WR1
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  subtype_constraints:
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: empty_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: abstract_supertype_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: true
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: total_over_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::References::SimpleReference
-      id: a
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_andor_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: b
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_and_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: b
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_andor_and_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: b
-        operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_and_andor_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: a
-        operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_parenthesis_andor_and_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-        operator: ANDOR
-        operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: a
-        operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_and_parenthesis_andor_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-        operator: ANDOR
-        operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: b
-        operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_oneof_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-      operands:
-      - _class: Expressir::Model::References::SimpleReference
-        id: a
-      - _class: Expressir::Model::References::SimpleReference
-        id: b
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_and_oneof_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-        - _class: Expressir::Model::References::SimpleReference
-          id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_andor_oneof_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::References::SimpleReference
-        id: a
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-        - _class: Expressir::Model::References::SimpleReference
-          id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_oneof_and_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: a
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_oneof_andor_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: a
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::References::SimpleReference
-        id: c
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_oneof_and_oneof_subtype_constraint
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: AND
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: a
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: c
-        - _class: Expressir::Model::References::SimpleReference
-          id: d
-  - _class: Expressir::Model::Declarations::SubtypeConstraint
-    id: supertype_expression_oneof_andor_oneof_subtype_constraint
-    remarks:
-    - functions
-    untagged_remarks:
-    - text: functions
-      format: tail
-    applies_to:
-      _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    abstract: false
-    supertype_expression:
-      _class: Expressir::Model::SupertypeExpressions::BinarySupertypeExpression
-      operator: ANDOR
-      operand1:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: a
-        - _class: Expressir::Model::References::SimpleReference
-          id: b
-      operand2:
-        _class: Expressir::Model::SupertypeExpressions::OneofSupertypeExpression
-        operands:
-        - _class: Expressir::Model::References::SimpleReference
-          id: c
-        - _class: Expressir::Model::References::SimpleReference
-          id: d
-  functions:
-  - _class: Expressir::Model::Declarations::Function
-    id: empty_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: parameter_function
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_parameter_function
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_shorthand_parameter_function
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: type_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    types:
-    - _class: Expressir::Model::Declarations::Type
-      id: test
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: constant_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_constant_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Constant
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: variable_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_variable_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_shorthand_variable_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: variable_expression_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_variable_expression_function
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Function
-    id: multiple_shorthand_variable_expression_function
-    remarks:
-    - rules
-    untagged_remarks:
-    - text: rules
-      format: tail
-    return_type:
-      _class: Expressir::Model::DataTypes::Boolean
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  rules:
-  - _class: Expressir::Model::Declarations::Rule
-    id: empty_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: type_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    types:
-    - _class: Expressir::Model::Declarations::Type
-      id: test
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Boolean
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: constant_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: multiple_constant_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Constant
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: variable_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: multiple_variable_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: multiple_shorthand_variable_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: variable_expression_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: multiple_variable_expression_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: multiple_shorthand_variable_expression_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: statement_rule
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    statements:
-    - _class: Expressir::Model::Statements::Null
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Rule
-    id: where_label_rule
-    remarks:
-    - procedures
-    untagged_remarks:
-    - text: procedures
-      format: tail
-    applies_to:
-    - _class: Expressir::Model::References::SimpleReference
-      id: empty_entity
-      base_path: spec/syntax/syntax.exp.syntax_schema.empty_entity
-    where_rules:
-    - _class: Expressir::Model::Declarations::WhereRule
-      id: WR1
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  procedures:
-  - _class: Expressir::Model::Declarations::Procedure
-    id: empty_procedure
-  - _class: Expressir::Model::Declarations::Procedure
-    id: parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_shorthand_parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: variable_parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      var: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_variable_parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      var: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_variable_parameter2_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      var: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_shorthand_variable_parameter_procedure
-    parameters:
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test
-      var: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Parameter
-      id: test2
-      var: true
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: type_procedure
-    types:
-    - _class: Expressir::Model::Declarations::Type
-      id: test
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: constant_procedure
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_constant_procedure
-    constants:
-    - _class: Expressir::Model::Declarations::Constant
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Constant
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Procedure
-    id: variable_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_variable_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_shorthand_variable_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-  - _class: Expressir::Model::Declarations::Procedure
-    id: variable_expression_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_variable_expression_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Procedure
-    id: multiple_shorthand_variable_expression_procedure
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: test
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: test2
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-  - _class: Expressir::Model::Declarations::Procedure
-    id: statement_procedure
-    statements:
-    - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Procedure
-    id: statements
-    remarks:
-    - statements
-    - simple types
-    untagged_remarks:
-    - text: statements
-      format: tail
-    - text: simple types
-      format: tail
-    procedures:
-    - _class: Expressir::Model::Declarations::Procedure
-      id: alias_simple_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Alias
-        id: test
-        expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: alias_group_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Alias
-        id: test
-        expression:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: test2
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: alias_index_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Alias
-        id: test
-        expression:
-          _class: Expressir::Model::References::IndexReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          index1:
-            _class: Expressir::Model::Literals::Integer
-            value: '1'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: alias_index2_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Alias
-        id: test
-        expression:
-          _class: Expressir::Model::References::IndexReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          index1:
-            _class: Expressir::Model::Literals::Integer
-            value: '1'
-          index2:
-            _class: Expressir::Model::Literals::Integer
-            value: '9'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: alias_attribute_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Alias
-        id: test
-        expression:
-          _class: Expressir::Model::References::AttributeReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          attribute:
-            _class: Expressir::Model::References::SimpleReference
-            id: test2
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: assignment_simple_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Assignment
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: assignment_group_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Assignment
-        ref:
-          _class: Expressir::Model::References::GroupReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          entity:
-            _class: Expressir::Model::References::SimpleReference
-            id: test2
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: assignment_index_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Assignment
-        ref:
-          _class: Expressir::Model::References::IndexReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          index1:
-            _class: Expressir::Model::Literals::Integer
-            value: '1'
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: assignment_index2_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Assignment
-        ref:
-          _class: Expressir::Model::References::IndexReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          index1:
-            _class: Expressir::Model::Literals::Integer
-            value: '1'
-          index2:
-            _class: Expressir::Model::Literals::Integer
-            value: '9'
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: assignment_attribute_reference_statement
-      statements:
-      - _class: Expressir::Model::Statements::Assignment
-        ref:
-          _class: Expressir::Model::References::AttributeReference
-          ref:
-            _class: Expressir::Model::References::SimpleReference
-            id: test
-          attribute:
-            _class: Expressir::Model::References::SimpleReference
-            id: test2
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: case_statement
-      statements:
-      - _class: Expressir::Model::Statements::Case
-        expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        actions:
-        - _class: Expressir::Model::Statements::CaseAction
-          labels:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          statement:
-            _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: case_multiple_statement
-      statements:
-      - _class: Expressir::Model::Statements::Case
-        expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        actions:
-        - _class: Expressir::Model::Statements::CaseAction
-          labels:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          statement:
-            _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::CaseAction
-          labels:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          statement:
-            _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: case_multiple_shorthand_statement
-      statements:
-      - _class: Expressir::Model::Statements::Case
-        expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        actions:
-        - _class: Expressir::Model::Statements::CaseAction
-          labels:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          statement:
-            _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: case_otherwise_statement
-      statements:
-      - _class: Expressir::Model::Statements::Case
-        expression:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        actions:
-        - _class: Expressir::Model::Statements::CaseAction
-          labels:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          statement:
-            _class: Expressir::Model::Statements::Null
-        otherwise_statement:
-          _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: compound_statement
-      statements:
-      - _class: Expressir::Model::Statements::Compound
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: escape_statement
-      statements:
-      - _class: Expressir::Model::Statements::Escape
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if2_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if_else_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-        else_statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if2_else_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::Null
-        else_statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if_else2_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-        else_statements:
-        - _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: if2_else2_statement
-      statements:
-      - _class: Expressir::Model::Statements::If
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::Null
-        else_statements:
-        - _class: Expressir::Model::Statements::Null
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: null_statement
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: call_statement
-      statements:
-      - _class: Expressir::Model::Statements::ProcedureCall
-        procedure:
-          _class: Expressir::Model::References::SimpleReference
-          id: empty_procedure
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
-    - _class: Expressir::Model::Declarations::Procedure
-      id: call_parameter_statement
-      statements:
-      - _class: Expressir::Model::Statements::ProcedureCall
-        procedure:
-          _class: Expressir::Model::References::SimpleReference
-          id: empty_procedure
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: call_parameter2_statement
-      statements:
-      - _class: Expressir::Model::Statements::ProcedureCall
-        procedure:
-          _class: Expressir::Model::References::SimpleReference
-          id: empty_procedure
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_procedure
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: call_insert_statement
-      statements:
-      - _class: Expressir::Model::Statements::ProcedureCall
-        procedure:
-          _class: Expressir::Model::References::SimpleReference
-          id: INSERT
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: call_remove_statement
-      statements:
-      - _class: Expressir::Model::Statements::ProcedureCall
-        procedure:
-          _class: Expressir::Model::References::SimpleReference
-          id: REMOVE
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: repeat_statement
-      statements:
-      - _class: Expressir::Model::Statements::Repeat
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: repeat_variable_statement
-      statements:
-      - _class: Expressir::Model::Statements::Repeat
-        id: test
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: repeat_variable_increment_statement
-      statements:
-      - _class: Expressir::Model::Statements::Repeat
-        id: test
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        increment:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: repeat_while_statement
-      statements:
-      - _class: Expressir::Model::Statements::Repeat
-        while_expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: repeat_until_statement
-      statements:
-      - _class: Expressir::Model::Statements::Repeat
-        until_expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        statements:
-        - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Procedure
-      id: return_statement
-      statements:
-      - _class: Expressir::Model::Statements::Return
-    - _class: Expressir::Model::Declarations::Procedure
-      id: return_expression_statement
-      statements:
-      - _class: Expressir::Model::Statements::Return
-        expression:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Procedure
-      id: skip_statement
-      statements:
-      - _class: Expressir::Model::Statements::Skip
-  - _class: Expressir::Model::Declarations::Procedure
-    id: types
-    remarks:
-    - aggregation types
-    - constructed types
-    - literal expressions
-    untagged_remarks:
-    - text: aggregation types
-      format: tail
-    - text: constructed types
-      format: tail
-    - text: literal expressions
-      format: tail
-    types:
-    - _class: Expressir::Model::Declarations::Type
-      id: binary_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Binary
-    - _class: Expressir::Model::Declarations::Type
-      id: binary_width_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Binary
-        width:
-          _class: Expressir::Model::Literals::Integer
-          value: '3'
-    - _class: Expressir::Model::Declarations::Type
-      id: binary_width_fixed_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Binary
-        width:
-          _class: Expressir::Model::Literals::Integer
-          value: '3'
-        fixed: true
-    - _class: Expressir::Model::Declarations::Type
-      id: boolean_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Boolean
-    - _class: Expressir::Model::Declarations::Type
-      id: integer_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Integer
-    - _class: Expressir::Model::Declarations::Type
-      id: logical_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Logical
-    - _class: Expressir::Model::Declarations::Type
-      id: number_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Number
-    - _class: Expressir::Model::Declarations::Type
-      id: real_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Real
-    - _class: Expressir::Model::Declarations::Type
-      id: real_precision_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Real
-        precision:
-          _class: Expressir::Model::Literals::Integer
-          value: '3'
-    - _class: Expressir::Model::Declarations::Type
-      id: string_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: string_width_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::String
-        width:
-          _class: Expressir::Model::Literals::Integer
-          value: '3'
-    - _class: Expressir::Model::Declarations::Type
-      id: string_width_fixed_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::String
-        width:
-          _class: Expressir::Model::Literals::Integer
-          value: '3'
-        fixed: true
-    - _class: Expressir::Model::Declarations::Type
-      id: array_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Array
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        optional: false
-        unique: false
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: array_optional_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Array
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        optional: true
-        unique: false
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: array_unique_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Array
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        optional: false
-        unique: true
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: array_optional_unique_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Array
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        optional: true
-        unique: true
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: bag_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Bag
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: bag_bound_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Bag
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: list_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::List
-        unique: false
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: list_bound_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::List
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        unique: false
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: list_unique_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::List
-        unique: true
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: list_bound_unique_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::List
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        unique: true
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: set_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Set
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: set_bound_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Set
-        bound1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        bound2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-        base_type:
-          _class: Expressir::Model::DataTypes::String
-    - _class: Expressir::Model::Declarations::Type
-      id: select_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-    - _class: Expressir::Model::Declarations::Type
-      id: select_extensible_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        extensible: true
-    - _class: Expressir::Model::Declarations::Type
-      id: select_extensible_generic_entity_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        extensible: true
-        generic_entity: true
-    - _class: Expressir::Model::Declarations::Type
-      id: select_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        items:
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-    - _class: Expressir::Model::Declarations::Type
-      id: select_multiple_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        items:
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-    - _class: Expressir::Model::Declarations::Type
-      id: select_based_on_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: select_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
-    - _class: Expressir::Model::Declarations::Type
-      id: select_based_on_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: select_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
-        items:
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-    - _class: Expressir::Model::Declarations::Type
-      id: select_based_on_multiple_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Select
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: select_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.select_type
-        items:
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-        - _class: Expressir::Model::References::SimpleReference
-          id: empty_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.empty_type
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_extensible_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        extensible: true
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_multiple_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test2
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_based_on_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: enumeration_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_based_on_item_type
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: enumeration_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test
-    - _class: Expressir::Model::Declarations::Type
-      id: enumeration_based_on_multiple_item_type
+    - schema scope - entity
+    - universal scope - entity
+    attributes:
+    - _class: Expressir::Model::Declarations::Attribute
+      id: remark_attribute
       remarks:
-      - generic types
-      untagged_remarks:
-      - text: generic types
-        format: tail
-      underlying_type:
-        _class: Expressir::Model::DataTypes::Enumeration
-        based_on:
-          _class: Expressir::Model::References::SimpleReference
-          id: enumeration_type
-          base_path: spec/syntax/syntax.exp.syntax_schema.types.enumeration_type
-        items:
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test
-        - _class: Expressir::Model::DataTypes::EnumerationItem
-          id: test2
-    functions:
-    - _class: Expressir::Model::Declarations::Function
-      id: generic_type
-      return_type:
-        _class: Expressir::Model::DataTypes::Generic
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Function
-      id: generic_label_type
-      return_type:
-        _class: Expressir::Model::DataTypes::Generic
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Function
-      id: generic_entity_type
-      return_type:
-        _class: Expressir::Model::DataTypes::GenericEntity
-      statements:
-      - _class: Expressir::Model::Statements::Null
-    - _class: Expressir::Model::Declarations::Function
-      id: generic_entity_label_type
-      return_type:
-        _class: Expressir::Model::DataTypes::GenericEntity
-      statements:
-      - _class: Expressir::Model::Statements::Null
-  - _class: Expressir::Model::Declarations::Procedure
-    id: expressions
-    remarks:
-    - constant expressions
-    - function expressions
-    - operator expressions
-    - aggregate initializer expressions
-    - function call or entity constructor expressions
-    - reference expressions
-    - interval expressions
-    untagged_remarks:
-    - text: constant expressions
-      format: tail
-    - text: function expressions
-      format: tail
-    - text: operator expressions
-      format: tail
-    - text: aggregate initializer expressions
-      format: tail
-    - text: function call or entity constructor expressions
-      format: tail
-    - text: reference expressions
-      format: tail
-    - text: interval expressions
-      format: tail
-    variables:
-    - _class: Expressir::Model::Declarations::Variable
-      id: binary_expression
+      - entity scope - entity attribute
+      - schema scope - entity attribute
+      - universal scope - entity attribute
+      kind: EXPLICIT
       type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Binary
-        value: "%011110000111100001111000"
-    - _class: Expressir::Model::Declarations::Variable
-      id: integer_expression
+        _class: Expressir::Model::DataTypes::String
+    - _class: Expressir::Model::Declarations::DerivedAttribute
+      id: remark_derived_attribute
+      remarks:
+      - entity scope - entity derived attribute
+      - schema scope - entity derived attribute
+      - universal scope - entity derived attribute
+      kind: DERIVED
       type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Integer
-        value: '999'
-    - _class: Expressir::Model::Declarations::Variable
-      id: true_logical_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: false_logical_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: 'FALSE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: unknown_logical_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Logical
-        value: UNKNOWN
-    - _class: Expressir::Model::Declarations::Variable
-      id: real_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::Real
-        value: '999.999'
-    - _class: Expressir::Model::Declarations::Variable
-      id: simple_string_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
+        _class: Expressir::Model::DataTypes::String
       expression:
         _class: Expressir::Model::Literals::String
         value: xxx
-    - _class: Expressir::Model::Declarations::Variable
-      id: utf8_simple_string_expression
+    - _class: Expressir::Model::Declarations::InverseAttribute
+      id: remark_inverse_attribute
+      remarks:
+      - entity scope - entity inverse attribute
+      - schema scope - entity inverse attribute
+      - universal scope - entity inverse attribute
+      kind: INVERSE
       type:
-        _class: Expressir::Model::DataTypes::Boolean
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_entity
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_attribute
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
+    unique_rules:
+    - _class: Expressir::Model::Declarations::UniqueRule
+      id: UR1
+      remarks:
+      - entity scope - entity unique
+      - schema scope - entity unique
+      - universal scope - entity unique
+      attributes:
+      - _class: Expressir::Model::References::SimpleReference
+        id: remark_attribute
+        base_path: spec/syntax/remark.exp.remark_schema.remark_entity.remark_attribute
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      id: WR1
+      remarks:
+      - entity scope - entity where
+      - entity scope - entity where, with prefix
+      - schema scope - entity where
+      - schema scope - entity where, with prefix
+      - universal scope - entity where
+      - universal scope - entity where, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: unusual_placement
+        remarks:
+        - placed inside WHERE clauses (or other enumerable context)
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    informal_propositions:
+    - _class: Expressir::Model::Declarations::InformalPropositionRule
+      id: IP1
+      remarks:
+      - entity scope - entity informal proposition, with prefix
+      - schema scope - entity informal proposition
+      - schema scope - entity informal proposition, with prefix
+      - universal scope - entity informal proposition
+      - universal scope - entity informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - entity scope - entity informal proposition
+  subtype_constraints:
+  - _class: Expressir::Model::Declarations::SubtypeConstraint
+    id: remark_subtype_constraint
+    remarks:
+    - schema scope - subtype constraint
+    - universal scope - subtype constraint
+    applies_to:
+      _class: Expressir::Model::References::SimpleReference
+      id: remark_entity
+      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
+    abstract: false
+  functions:
+  - _class: Expressir::Model::Declarations::Function
+    id: remark_function
+    remarks:
+    - schema scope - function
+    - universal scope - function
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: remark_parameter
+      remarks:
+      - function scope - function parameter
+      - schema scope - function parameter
+      - universal scope - function parameter
+      type:
+        _class: Expressir::Model::DataTypes::String
+    return_type:
+      _class: Expressir::Model::DataTypes::Boolean
+    types:
+    - _class: Expressir::Model::Declarations::Type
+      id: remark_type
+      remarks:
+      - function scope - function type
+      - schema scope - function type
+      - universal scope - function type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: remark_enumeration_item
+          remarks:
+          - function scope - function enumeration item
+          - function scope - function enumeration item, on the same level as the type
+          - schema scope - function enumeration item
+          - schema scope - function enumeration item, on the same level as the type
+          - universal scope - function enumeration item
+          - universal scope - function enumeration item, on the same level as the
+            type
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: remark_constant
+      remarks:
+      - function scope - function constant
+      - schema scope - function constant
+      - universal scope - function constant
+      type:
+        _class: Expressir::Model::DataTypes::String
       expression:
         _class: Expressir::Model::Literals::String
-        value: 'UTF8 test: Příliš žluťoučký kůň úpěl ďábelské ódy.'
+        value: xxx
+    variables:
     - _class: Expressir::Model::Declarations::Variable
-      id: encoded_string_expression
+      id: remark_variable
+      remarks:
+      - function scope - function variable
+      - schema scope - function variable
+      - universal scope - function variable
       type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Literals::String
-        value: '000000780000007800000078'
-        encoded: true
-    - _class: Expressir::Model::Declarations::Variable
-      id: const_e_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: CONST_E
-    - _class: Expressir::Model::Declarations::Variable
-      id: indeterminate_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
+        _class: Expressir::Model::DataTypes::String
+    statements:
+    - _class: Expressir::Model::Statements::Alias
+      id: remark_alias
+      remarks:
+      - function alias scope - function alias
       expression:
         _class: Expressir::Model::References::SimpleReference
-        id: "?"
-    - _class: Expressir::Model::Declarations::Variable
-      id: pi_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: PI
-    - _class: Expressir::Model::Declarations::Variable
-      id: self_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::SimpleReference
-        id: SELF
-    - _class: Expressir::Model::Declarations::Variable
-      id: abs_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ABS
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: acos_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ACOS
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: asin_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ASIN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: atan_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ATAN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: blength_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: BLENGTH
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: cos_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: COS
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: exists_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: EXISTS
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: exp_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: EXP
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: format_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: FORMAT
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: hibound_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: HIBOUND
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: hiindex_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: HIINDEX
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: length_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LENGTH
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lobound_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LOBOUND
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: loindex_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LOINDEX
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: log_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LOG
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: log2_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LOG2
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: log10_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: LOG10
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: nvl_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: NVL
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: odd_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ODD
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: rolesof_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: ROLESOF
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: sin_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: SIN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: sizeof_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: SIZEOF
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: sqrt_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: SQRT
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: tan_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: TAN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: typeof_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: TYPEOF
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: usedin_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: USEDIN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: value_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: VALUE
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: value_in_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: VALUE_IN
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: value_unique_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: VALUE_UNIQUE
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: plus_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: PLUS
-        operand:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-    - _class: Expressir::Model::Declarations::Variable
-      id: plus_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: PLUS
-        operand:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: minus_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: MINUS
-        operand:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-    - _class: Expressir::Model::Declarations::Variable
-      id: minus_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: MINUS
-        operand:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: ADDITION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: subtraction_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: SUBTRACTION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: multiplication_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: MULTIPLICATION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: real_division_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: REAL_DIVISION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: integer_division_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: INTEGER_DIVISION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: modulo_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: MODULO
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: exponentiation_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Repeat
+      id: remark_repeat
+      remarks:
+      - function repeat scope - function repeat
+      bound1:
         _class: Expressir::Model::Literals::Integer
-        value: '4'
-    - _class: Expressir::Model::Declarations::Variable
-      id: addition_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: ADDITION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-    - _class: Expressir::Model::Declarations::Variable
-      id: subtraction_subtraction_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: SUBTRACTION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: SUBTRACTION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-    - _class: Expressir::Model::Declarations::Variable
-      id: addition_subtraction_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: SUBTRACTION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-    - _class: Expressir::Model::Declarations::Variable
-      id: subtraction_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: ADDITION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: SUBTRACTION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-    - _class: Expressir::Model::Declarations::Variable
-      id: addition_multiplication_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: ADDITION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '8'
-        operand2:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: MULTIPLICATION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: multiplication_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: ADDITION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: MULTIPLICATION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '8'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: parenthesis_addition_multiplication_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: MULTIPLICATION
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '8'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: multiplication_parenthesis_addition_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: MULTIPLICATION
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '8'
-        operand2:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: equal_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: not_equal_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: NOT_EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: instance_equal_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: INSTANCE_EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: instance_not_equal_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: INSTANCE_NOT_EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lt_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: LESS_THAN
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: gt_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: GREATER_THAN
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lte_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: LESS_THAN_OR_EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: gte_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: GREATER_THAN_OR_EQUAL
-        operand1:
-          _class: Expressir::Model::Literals::Integer
-          value: '4'
-        operand2:
-          _class: Expressir::Model::Literals::Integer
-          value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: not_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: NOT
-        operand:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: not_or_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::UnaryExpression
-        operator: NOT
-        operand:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: OR
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: or_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: OR
-        operand1:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'FALSE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: and_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'FALSE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: or_or_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: OR
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: OR
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: and_and_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: AND
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: or_and_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: OR
-        operand1:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        operand2:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: AND
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: and_or_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: OR
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: AND
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: parenthesis_or_and_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: OR
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-        operand2:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: and_parenthesis_or_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: AND
-        operand1:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        operand2:
-          _class: Expressir::Model::Expressions::BinaryExpression
-          operator: OR
-          operand1:
-            _class: Expressir::Model::Literals::Logical
-            value: 'FALSE'
-          operand2:
-            _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: combine_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: COMBINE
-        operand1:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        operand2:
-          _class: Expressir::Model::References::SimpleReference
-          id: test2
-    - _class: Expressir::Model::Declarations::Variable
-      id: in_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: IN
-        operand1:
-          _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-        operand2:
-          _class: Expressir::Model::Expressions::AggregateInitializer
-          items:
-          - _class: Expressir::Model::Literals::Logical
-            value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: like_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::BinaryExpression
-        operator: LIKE
-        operand1:
-          _class: Expressir::Model::Literals::String
-          value: xxx
-        operand2:
-          _class: Expressir::Model::Literals::String
-          value: xxx
-    - _class: Expressir::Model::Declarations::Variable
-      id: aggregate_initializer_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::AggregateInitializer
-        items:
-        - _class: Expressir::Model::Literals::Integer
-          value: '4'
-    - _class: Expressir::Model::Declarations::Variable
-      id: repeated_aggregate_initializer_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::AggregateInitializer
-        items:
-        - _class: Expressir::Model::Literals::Integer
-          value: '4'
-    - _class: Expressir::Model::Declarations::Variable
-      id: complex_aggregate_initializer_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::AggregateInitializer
-        items:
-        - _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: complex_repeated_aggregate_initializer_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::AggregateInitializer
-        items:
-        - _class: Expressir::Model::Expressions::BinaryExpression
-          operator: ADDITION
-          operand1:
-            _class: Expressir::Model::Literals::Integer
-            value: '4'
-          operand2:
-            _class: Expressir::Model::Literals::Integer
-            value: '2'
-    - _class: Expressir::Model::Declarations::Variable
-      id: call_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::FunctionCall
-        function:
-          _class: Expressir::Model::References::SimpleReference
-          id: parameter_function
-          base_path: spec/syntax/syntax.exp.syntax_schema.parameter_function
-        parameters:
-        - _class: Expressir::Model::Literals::Logical
-          value: 'TRUE'
-    - _class: Expressir::Model::Declarations::Variable
-      id: simple_reference_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
+        value: '1'
+      bound2:
+        _class: Expressir::Model::Literals::Integer
+        value: '9'
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Assignment
+      ref:
         _class: Expressir::Model::References::SimpleReference
-        id: test
-    - _class: Expressir::Model::Declarations::Variable
-      id: group_reference_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::GroupReference
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        entity:
-          _class: Expressir::Model::References::SimpleReference
-          id: test2
-    - _class: Expressir::Model::Declarations::Variable
-      id: index_reference_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::IndexReference
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        index1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-    - _class: Expressir::Model::Declarations::Variable
-      id: index2_reference_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::IndexReference
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        index1:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        index2:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-    - _class: Expressir::Model::Declarations::Variable
-      id: attribute_reference_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::References::AttributeReference
-        ref:
-          _class: Expressir::Model::References::SimpleReference
-          id: test
-        attribute:
-          _class: Expressir::Model::References::SimpleReference
-          id: test2
-    - _class: Expressir::Model::Declarations::Variable
-      id: lt_lt_interval_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::Interval
-        low:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        operator1: LESS_THAN
-        item:
-          _class: Expressir::Model::Literals::Integer
-          value: '5'
-        operator2: LESS_THAN
-        high:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lte_lt_interval_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::Interval
-        low:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        operator1: LESS_THAN_OR_EQUAL
-        item:
-          _class: Expressir::Model::Literals::Integer
-          value: '5'
-        operator2: LESS_THAN
-        high:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lt_lte_interval_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::Interval
-        low:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        operator1: LESS_THAN
-        item:
-          _class: Expressir::Model::Literals::Integer
-          value: '5'
-        operator2: LESS_THAN_OR_EQUAL
-        high:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-    - _class: Expressir::Model::Declarations::Variable
-      id: lte_lte_interval_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
-      expression:
-        _class: Expressir::Model::Expressions::Interval
-        low:
-          _class: Expressir::Model::Literals::Integer
-          value: '1'
-        operator1: LESS_THAN_OR_EQUAL
-        item:
-          _class: Expressir::Model::Literals::Integer
-          value: '5'
-        operator2: LESS_THAN_OR_EQUAL
-        high:
-          _class: Expressir::Model::Literals::Integer
-          value: '9'
-    - _class: Expressir::Model::Declarations::Variable
-      id: query_expression
-      type:
-        _class: Expressir::Model::DataTypes::Boolean
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
       expression:
         _class: Expressir::Model::Expressions::QueryExpression
-        id: test
+        id: remark_query
+        remarks:
+        - function query scope - function query
         aggregate_source:
           _class: Expressir::Model::References::SimpleReference
-          id: test2
+          id: remark_variable
+          base_path: spec/syntax/remark.exp.remark_schema.remark_function.remark_variable
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+  rules:
+  - _class: Expressir::Model::Declarations::Rule
+    id: remark_rule
+    remarks:
+    - schema scope - rule
+    - universal scope - rule
+    applies_to:
+    - _class: Expressir::Model::References::SimpleReference
+      id: remark_entity
+      base_path: spec/syntax/remark.exp.remark_schema.remark_entity
+    types:
+    - _class: Expressir::Model::Declarations::Type
+      id: remark_type
+      remarks:
+      - rule scope - rule type
+      - schema scope - rule type
+      - universal scope - rule type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: remark_enumeration_item
+          remarks:
+          - rule scope - rule enumeration item
+          - rule scope - rule enumeration item, on the same level as the type
+          - schema scope - rule enumeration item
+          - schema scope - rule enumeration item, on the same level as the type
+          - universal scope - rule enumeration item
+          - universal scope - rule enumeration item, on the same level as the type
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: remark_constant
+      remarks:
+      - rule scope - rule constant
+      - schema scope - rule constant
+      - universal scope - rule constant
+      type:
+        _class: Expressir::Model::DataTypes::String
+      expression:
+        _class: Expressir::Model::Literals::String
+        value: xxx
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: remark_variable
+      remarks:
+      - rule scope - rule variable
+      - schema scope - rule variable
+      - universal scope - rule variable
+      type:
+        _class: Expressir::Model::DataTypes::String
+    statements:
+    - _class: Expressir::Model::Statements::Alias
+      id: remark_alias
+      remarks:
+      - rule alias scope - rule alias
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Repeat
+      id: remark_repeat
+      remarks:
+      - rule repeat scope - rule repeat
+      bound1:
+        _class: Expressir::Model::Literals::Integer
+        value: '1'
+      bound2:
+        _class: Expressir::Model::Literals::Integer
+        value: '9'
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Assignment
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
+      expression:
+        _class: Expressir::Model::Expressions::QueryExpression
+        id: remark_query
+        remarks:
+        - rule query scope - rule query
+        aggregate_source:
+          _class: Expressir::Model::References::SimpleReference
+          id: remark_variable
+          base_path: spec/syntax/remark.exp.remark_schema.remark_rule.remark_variable
+        expression:
+          _class: Expressir::Model::Literals::Logical
+          value: 'TRUE'
+    where_rules:
+    - _class: Expressir::Model::Declarations::WhereRule
+      id: WR1
+      remarks:
+      - rule scope - rule where
+      - rule scope - rule where, with prefix
+      - schema scope - rule where
+      - schema scope - rule where, with prefix
+      - universal scope - rule where
+      - universal scope - rule where, with prefix
+      expression:
+        _class: Expressir::Model::Literals::Logical
+        value: 'TRUE'
+    informal_propositions:
+    - _class: Expressir::Model::Declarations::InformalPropositionRule
+      id: IP1
+      remarks:
+      - rule scope - rule informal proposition, with prefix
+      - schema scope - rule informal proposition
+      - schema scope - rule informal proposition, with prefix
+      - universal scope - rule informal proposition
+      - universal scope - rule informal proposition, with prefix
+      remark_items:
+      - _class: Expressir::Model::Declarations::RemarkItem
+        id: IP1
+        remarks:
+        - rule scope - rule informal proposition
+  procedures:
+  - _class: Expressir::Model::Declarations::Procedure
+    id: remark_procedure
+    remarks:
+    - schema scope - procedure
+    - universal scope - procedure
+    parameters:
+    - _class: Expressir::Model::Declarations::Parameter
+      id: remark_parameter
+      remarks:
+      - procedure scope - procedure parameter
+      - schema scope - procedure parameter
+      - universal scope - procedure parameter
+      type:
+        _class: Expressir::Model::DataTypes::String
+    types:
+    - _class: Expressir::Model::Declarations::Type
+      id: remark_type
+      remarks:
+      - procedure scope - procedure type
+      - schema scope - procedure type
+      - universal scope - procedure type
+      underlying_type:
+        _class: Expressir::Model::DataTypes::Enumeration
+        items:
+        - _class: Expressir::Model::DataTypes::EnumerationItem
+          id: remark_enumeration_item
+          remarks:
+          - procedure scope - procedure enumeration item
+          - procedure scope - procedure enumeration item, on the same level as the
+            type
+          - schema scope - procedure enumeration item
+          - schema scope - procedure enumeration item, on the same level as the type
+          - universal scope - procedure enumeration item
+          - universal scope - procedure enumeration item, on the same level as the
+            type
+    constants:
+    - _class: Expressir::Model::Declarations::Constant
+      id: remark_constant
+      remarks:
+      - procedure scope - procedure constant
+      - schema scope - procedure constant
+      - universal scope - procedure constant
+      type:
+        _class: Expressir::Model::DataTypes::String
+      expression:
+        _class: Expressir::Model::Literals::String
+        value: xxx
+    variables:
+    - _class: Expressir::Model::Declarations::Variable
+      id: remark_variable
+      remarks:
+      - procedure scope - procedure variable
+      - schema scope - procedure variable
+      - universal scope - procedure variable
+      type:
+        _class: Expressir::Model::DataTypes::String
+    statements:
+    - _class: Expressir::Model::Statements::Alias
+      id: remark_alias
+      remarks:
+      - procedure alias scope - procedure alias
+      expression:
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Repeat
+      id: remark_repeat
+      remarks:
+      - procedure repeat scope - procedure repeat
+      bound1:
+        _class: Expressir::Model::Literals::Integer
+        value: '1'
+      bound2:
+        _class: Expressir::Model::Literals::Integer
+        value: '9'
+      statements:
+      - _class: Expressir::Model::Statements::Null
+    - _class: Expressir::Model::Statements::Assignment
+      ref:
+        _class: Expressir::Model::References::SimpleReference
+        id: remark_variable
+        base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
+      expression:
+        _class: Expressir::Model::Expressions::QueryExpression
+        id: remark_query
+        remarks:
+        - procedure query scope - procedure query
+        aggregate_source:
+          _class: Expressir::Model::References::SimpleReference
+          id: remark_variable
+          base_path: spec/syntax/remark.exp.remark_schema.remark_procedure.remark_variable
         expression:
           _class: Expressir::Model::Literals::Logical
           value: 'TRUE'


### PR DESCRIPTION
The metanorma/ci reusable workflow's nested job 'tests-passed' requests contents: write but the caller only granted contents: read, causing startup_failure on every rake CI run since the workflow was updated upstream.