### PR TITLE
refactor: deepen the remark pipeline (scope resolver, node index, format vocabulary)

### DIFF
--- a/lib/expressir/express.rb
+++ b/lib/expressir/express.rb
@@ -14,6 +14,7 @@ module Expressir
     autoload :HyperlinkFormatter, "#{__dir__}/express/hyperlink_formatter"
     autoload :LineMap, "#{__dir__}/express/line_map"
     autoload :ModelVisitor, "#{__dir__}/express/model_visitor"
+    autoload :NodePositionIndex, "#{__dir__}/express/node_position_index"
     autoload :Parser, "#{__dir__}/express/parser"
     autoload :PrettyFormatter, "#{__dir__}/express/pretty_formatter"
     autoload :RemarkAttacher, "#{__dir__}/express/remark_attacher"
@@ -21,6 +22,7 @@ module Expressir
     autoload :ResolveReferencesModelVisitor,
              "#{__dir__}/express/resolve_references_model_visitor"
     autoload :SchemaHeadFormatter, "#{__dir__}/express/schema_head_formatter"
+    autoload :ScopeResolver, "#{__dir__}/express/scope_resolver"
     autoload :StreamingBuilder, "#{__dir__}/express/streaming_builder"
 
     autoload :Transformer, "#{__dir__}/express/transformer"

--- a/lib/expressir/express/node_position_index.rb
+++ b/lib/expressir/express/node_position_index.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+module Expressir
+  module Express
+    # Builds and queries an index of model nodes by source position.
+    #
+    # One interface (`nearest_node_to`, `node_for_end_scope_at`, `each_node`),
+    # one implementation. Extracted from RemarkAttacher so the tree-walk +
+    # byte→line translation + nearest-node heuristics live in one place,
+    # tested independently of any remark logic.
+    #
+    # Reference: ISO 10303-11 — the parser yields source spans on ModelElement
+    # instances; this module turns those spans into a line-keyed index that
+    # remark attachment can query.
+    class NodePositionIndex
+      # Type-driven registry: maps each model class to its collection
+      # attributes. Single source of truth for "what collections does this
+      # node have" — used by both RemarkAttacher and NodePositionIndex.
+      COLLECTION_REGISTRY = {
+        Model::Declarations::Schema => %i[
+          constants types entities subtype_constraints
+          functions rules procedures remark_items
+        ],
+        Model::Declarations::Entity => %i[
+          attributes derived_attributes inverse_attributes
+          unique_rules where_rules informal_propositions remark_items
+        ],
+        Model::Declarations::Function => %i[
+          parameters types entities subtype_constraints
+          functions procedures constants variables statements remark_items
+        ],
+        Model::Declarations::Procedure => %i[
+          parameters types entities subtype_constraints
+          functions procedures constants variables statements remark_items
+        ],
+        Model::Declarations::Rule => %i[
+          applies_to types entities subtype_constraints
+          functions procedures constants variables statements
+          where_rules informal_propositions remark_items
+        ],
+        Model::Declarations::Type => %i[
+          where_rules informal_propositions remark_items
+        ],
+        Model::ExpFile => %i[schemas],
+        Model::Statements::Compound => %i[statements],
+        Model::Statements::If => %i[statements],
+        Model::Statements::Alias => %i[statements],
+        Model::Statements::Repeat => %i[statements],
+      }.freeze
+
+      attr_reader :nodes
+
+      def initialize(model, line_map)
+        @model = model
+        @line_map = line_map
+        @nodes = build_sorted_nodes
+      end
+
+      # Returns the most-specific node whose span contains `remark_line`,
+      # preferring same-line starts/ends, then smallest containing span.
+      # Excludes Repository and Cache (not semantic scopes for remarks).
+      def nearest_node_to(remark_line)
+        same_start = nodes.select do |n|
+          n[:line] == remark_line && semantic?(n[:node])
+        end
+        return same_start.last[:node] if same_start.any?
+
+        same_end = nodes.select do |n|
+          n[:end_line] == remark_line && semantic?(n[:node])
+        end
+        return same_end.last[:node] if same_end.any?
+
+        containing = nodes.select do |n|
+          n[:line] && n[:end_line] &&
+            n[:line] <= remark_line && n[:end_line] >= remark_line &&
+            semantic?(n[:node])
+        end
+
+        if containing.any?
+          exp_file_node = containing.find { |n| n[:node].is_a?(Model::ExpFile) }
+          if exp_file_node
+            first_schema_offset = exp_file_node[:node].schemas&.first&.source_offset
+            if first_schema_offset && remark_line < @line_map.line_number(first_schema_offset)
+              return exp_file_node[:node]
+            end
+          end
+          containing.min_by { |n| n[:end_line] - n[:line] }[:node]
+        else
+          before = nodes.select do |n|
+            n[:end_line] && n[:end_line] < remark_line && semantic?(n[:node])
+          end
+          before.max_by { |n| n[:end_line] }[:node] if before.any?
+        end
+      end
+
+      # Returns the node whose END_XXX declaration is on `remark_line`, when
+      # the line text matches one of the END_XXX keywords. Used to attach
+      # remarks that appear immediately after a scope closes.
+      def node_for_end_scope_at(remark_line, line_content)
+        node_type = case line_content
+                    when /END_SCHEMA/i then Model::Declarations::Schema
+                    when /END_ENTITY/i then Model::Declarations::Entity
+                    when /END_TYPE/i then Model::Declarations::Type
+                    when /END_FUNCTION/i then Model::Declarations::Function
+                    when /END_PROCEDURE/i then Model::Declarations::Procedure
+                    when /END_RULE/i then Model::Declarations::Rule
+                    end
+        return nil unless node_type
+
+        matching = nodes.select do |n|
+          n[:node].is_a?(node_type) &&
+            (n[:end_line] == remark_line ||
+             (n[:end_line] && n[:end_line] <= remark_line && n[:end_line] >= remark_line - 2))
+        end
+
+        matching.first&.dig(:node) || nodes.find { |n| n[:node].is_a?(node_type) }&.dig(:node)
+      end
+
+      private
+
+      def semantic?(node)
+        !node.is_a?(Model::Repository) && !node.is_a?(Model::Cache)
+      end
+
+      def build_sorted_nodes
+        result = []
+        collect_nodes(@model, result, Set.new)
+        result.sort_by!.with_index { |n, i| [n[:position] || Float::INFINITY, i] }
+        result
+      end
+
+      def collect_nodes(node, result, visited)
+        return unless node
+        return if visited.include?(node.object_id)
+
+        visited.add(node.object_id)
+
+        if node.is_a?(Model::ModelElement) && node.source && node.source_offset
+          record_node_position(node, result)
+        else
+          result << { node: node, position: nil, line: nil, end_line: nil }
+        end
+
+        collect_children(node, result, visited)
+      end
+
+      def record_node_position(node, result)
+        pos = node.source_offset
+        valid = position_valid?(pos, node)
+        unless valid
+          result << { node: node, position: nil, line: nil, end_line: nil }
+          return
+        end
+
+        line = @line_map.line_number(pos)
+        source_end_line = @line_map.line_number(pos + node.source.length)
+        children_end_line = children_end_line_for(node)
+        end_line = [source_end_line, children_end_line].compact.max || source_end_line
+
+        result << { node: node, position: pos, line: line, end_line: end_line }
+      end
+
+      # The parser returns source_offset=0 for leaf nodes (WhereRule) where
+      # it cannot determine the actual position. Accept position=0 only when
+      # the source is a declaration keyword line — those legitimately start
+      # at the beginning of the file.
+      def position_valid?(pos, node)
+        return true if pos.positive?
+        return false unless pos.zero? && node.source
+
+        node.source.to_s.start_with?(
+          "SCHEMA", "ENTITY", "TYPE", "FUNCTION",
+          "PROCEDURE", "RULE", "CONSTANT", "VARIABLE",
+          "USE", "REFERENCE", "END_SCHEMA", "END_ENTITY",
+          "END_TYPE", "END_FUNCTION", "END_PROCEDURE",
+          "END_RULE", "END_CONSTANT", "END_VARIABLE"
+        )
+      end
+
+      def children_end_line_for(node)
+        end_lines = []
+
+        if node.is_a?(Model::Declarations::Schema)
+          Array(node.children).each do |child|
+            next unless child.is_a?(Model::ModelElement) && child.source_offset && child.source
+
+            end_lines << @line_map.line_number(child.source_offset + child.source.length)
+          end
+        end
+
+        each_collection_on(node) do |item|
+          next unless item.is_a?(Model::ModelElement) && item.source_offset && item.source
+
+          end_lines << @line_map.line_number(item.source_offset + item.source.length)
+        end
+
+        end_lines.max
+      end
+
+      def collect_children(node, result, visited)
+        if node.is_a?(Model::Declarations::Schema)
+          Array(node.children).each { |c| collect_nodes(c, result, visited) }
+        end
+
+        each_collection_on(node) do |item|
+          collect_nodes(item, result, visited)
+        end
+      end
+
+      # Yields each child in any declared collection on the node, based on
+      # the type-driven COLLECTION_REGISTRY. Returns nothing for nodes whose
+      # class is not registered.
+      def each_collection_on(node, &block)
+        attrs = COLLECTION_REGISTRY[node.class]
+        return unless attrs
+
+        attrs.each do |attr|
+          collection = node.public_send(attr)
+          next unless collection.is_a?(Array)
+
+          collection.each(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/expressir/express/remark_attacher.rb
+++ b/lib/expressir/express/remark_attacher.rb
@@ -4,6 +4,14 @@ module Expressir
   module Express
     # Handles attaching remarks (comments) to model elements after parsing.
     #
+    # Two collaborators sit behind the `attach` interface:
+    # - {ScopeResolver} answers "which scope contains line N?"
+    # - {NodePositionIndex} answers "which model node is nearest line N?"
+    #
+    # Remark scanning itself lives in {RemarkScanner}; line→byte lookup lives
+    # in {LineMap}. This class is the orchestrator: it walks the remarks, asks
+    # the collaborators for targets, and writes the remarks onto the model.
+    #
     # NOTE: Post-processing remark attachment has inherent limitations for scope-based
     # matching. Remarks with simple tags (like "WR1") inside scopes (TYPE, ENTITY, etc.)
     # cannot be perfectly matched without parsing context. This implementation prioritizes:
@@ -12,374 +20,10 @@ module Expressir
     # 3. NOT creating spurious schema-level items for ambiguous tags
     class RemarkAttacher
       # Type-driven registry: maps each model class to its collection attributes.
-      # Replaces runtime method probing (method_defined?) with explicit type declarations.
-      COLLECTION_REGISTRY = {
-        Model::Declarations::Schema => %i[
-          constants types entities subtype_constraints
-          functions rules procedures remark_items
-        ],
-        Model::Declarations::Entity => %i[
-          attributes derived_attributes inverse_attributes
-          unique_rules where_rules informal_propositions remark_items
-        ],
-        Model::Declarations::Function => %i[
-          parameters types entities subtype_constraints
-          functions procedures constants variables statements remark_items
-        ],
-        Model::Declarations::Procedure => %i[
-          parameters types entities subtype_constraints
-          functions procedures constants variables statements remark_items
-        ],
-        Model::Declarations::Rule => %i[
-          applies_to types entities subtype_constraints
-          functions procedures constants variables statements
-          where_rules informal_propositions remark_items
-        ],
-        Model::Declarations::Type => %i[
-          where_rules informal_propositions remark_items
-        ],
-        Model::ExpFile => %i[schemas],
-        Model::Statements::Compound => %i[statements],
-        Model::Statements::If => %i[statements],
-        Model::Statements::Alias => %i[statements],
-        Model::Statements::Repeat => %i[statements],
-      }.freeze
-
-      def initialize(source)
-        @source = source
-        @attached_spans = Set.new
-        @line_map = LineMap.new(source.b)
-        @model = nil
-        @source_lines = nil # cached @source.lines
-        @scope_map = nil # cached scope at each line number
-      end
-
-      def attach(model)
-        @model = model
-        remarks = RemarkScanner.new(@source).scan
-
-        # Build nodes_with_positions ONCE for both tagged and untagged remark passes.
-        # This avoids double tree walk (381K nodes × 2 = 762K visits) which was
-        # the largest memory overhead in remark attachment (~430MB for large files).
-        nodes_with_positions = build_sorted_nodes_with_positions(model)
-
-        attach_tagged_remarks(model, remarks, nodes_with_positions)
-        attach_untagged_remarks(remarks, nodes_with_positions)
-
-        # Free expensive data structures after attachment is complete.
-        # These are only needed during the attach process.
-        @source = nil
-        @source_lines = nil
-        @scope_map = nil
-        @line_map = nil
-
-        model
-      end
-
-      private
-
-      # Remark extraction lives in {RemarkScanner}; this class only attaches.
-      # Line-number lookup is delegated to {LineMap} for O(log n) queries.
-
-      def source_lines
-        @source_lines ||= @source.lines
-      end
-
-      def get_line_number(position)
-        @line_map.line_number(position)
-      end
-
-      def attach_tagged_remarks(model, remarks, nodes_with_positions)
-        tagged = remarks.select { |r| r[:tag] }
-        return if tagged.empty?
-
-        @model = model
-
-        # Build scope map ONCE: O(file_lines) scan instead of O(n*file_lines) for n remarks
-        # This is the key optimization that makes scope lookup O(1) per remark
-        @scope_map ||= build_scope_map
-
-        tagged.sort_by(&:position).each do |remark|
-          next if @attached_spans.include?(remark.position)
-
-          tag = remark.tag
-          target = nil
-
-          # Find containing scope using pre-computed scope map (O(1))
-          # Falls back to position-based lookup if scope map doesn't have the line
-          containing_scope = find_containing_scope_by_name(remark.line)
-          containing_scope ||= find_containing_scope_position(remark.line,
-                                                              nodes_with_positions)
-
-          # Check if this is an informal proposition tag (IP\d+)
-          if tag.match?(/^IP\d+$/)
-            scope = containing_scope
-            if scope.nil?
-              scope = find_scope_by_source_text(remark.line)
-            end
-            if scope && supports_informal_propositions?(scope)
-              target = create_or_find_informal_proposition(scope, tag)
-            end
-          end
-
-          # Standard path-based lookup
-          if target.nil?
-            # Handle prefixed tags like wr:WR1, ip:IP1, ur:UR1
-            if tag.include?(":") && !tag.include?(".")
-              target = handle_prefixed_tag(tag, containing_scope, model,
-                                           get_schema_ids(model))
-            end
-
-            # Strategy 1: Try exact path lookup
-            if target.nil?
-              target = find_by_exact_path(model, tag)
-            end
-
-            # Strategy 1b: For paths with dots, try with scope path prefix first
-            if target.nil? && tag.include?(".")
-              # First, try building full path from containing scope
-              if containing_scope && function_rule_procedure?(containing_scope)
-                scope_path = build_scope_path(containing_scope)
-                if scope_path
-                  full_path = "#{scope_path}.#{tag}"
-                  target = find_by_exact_path(model, full_path)
-                end
-              end
-
-              # Then try schema prefix
-              if target.nil?
-                schema_ids = get_schema_ids(model)
-                schema_ids.each do |schema_id|
-                  target = find_by_exact_path(model, "#{schema_id}.#{tag}")
-                  break if target
-                end
-              end
-            end
-
-            # Strategy 2: For simple tags, find in containing scope first
-            if target.nil? && !tag.include?(".")
-              if containing_scope
-                # Search within the containing scope
-                target = find_node_in_scope(containing_scope, tag)
-
-                # Special handling for remarks inside WHERE clauses
-                if target.nil? && supports_where_rules?(containing_scope)
-                  target = find_target_in_where_clause(containing_scope, tag,
-                                                       remark.line)
-                end
-
-                # Only fall back to schema prefix if NOT inside a function/rule/procedure
-                if target.nil? && !function_rule_procedure?(containing_scope)
-                  schema_ids = get_schema_ids(model)
-                  schema_ids.each do |schema_id|
-                    target = find_by_exact_path(model, "#{schema_id}.#{tag}")
-                    break if target
-                  end
-                end
-              else
-                # No containing scope, try with schema prefix
-                schema_ids = get_schema_ids(model)
-                schema_ids.each do |schema_id|
-                  target = find_by_exact_path(model, "#{schema_id}.#{tag}")
-                  break if target
-                end
-              end
-            end
-
-            # Strategy 3: Create implicit item for qualified paths only
-            if target.nil? && tag.include?(".")
-              # Try with scope path first
-              if containing_scope && function_rule_procedure?(containing_scope)
-                scope_path = build_scope_path(containing_scope)
-                if scope_path
-                  full_path = "#{scope_path}.#{tag}"
-                  target = create_implicit_remark_item(model, full_path,
-                                                       get_schema_ids(model))
-                end
-              end
-              # Fall back to schema prefix
-              if target.nil?
-                target = create_implicit_remark_item(model, tag,
-                                                     get_schema_ids(model))
-              end
-            end
-
-            # Strategy 4: For simple tags at schema level, create implicit item
-            if target.nil? && !tag.include?(".")
-              schema_ids = get_schema_ids(model)
-              if schema_ids.any?
-                target = create_implicit_remark_item_at_schema(model, tag,
-                                                               schema_ids.first)
-              end
-            end
-          end
-
-          if target
-            add_remark(target, remark.text, format: remark.format, tag: remark.tag)
-            @attached_spans << remark.position
-          end
-        end
-      end
-
-      # Position-based fallback for finding containing scope.
-      # Used when scope map lookup returns nil (e.g., for remarks at lines
-      # outside any declared scope's end_line, or for non-scope-containers).
-      def find_containing_scope_position(remark_line, nodes_with_positions)
-        containing_nodes = nodes_with_positions.select do |n|
-          n[:line] && n[:end_line] && remark_line >= n[:line] && remark_line <= n[:end_line] &&
-            !repository?(n[:node]) && !cache?(n[:node])
-        end
-
-        containing_nodes.reverse_each do |n|
-          node = n[:node]
-          return node if node.is_a?(Model::ScopeContainer)
-        end
-
-        nil
-      end
-
-      # Done once per RemarkAttacher instance (O(file_lines)).
-      # Each find_containing_scope call then becomes O(1).
-      def build_scope_map
-        lines = source_lines
-        scope_map = {}
-        return scope_map if lines.empty?
-
-        # Track nested scopes by scanning all lines once
-        scope_stack = [] # array of {type:, name:, line:}
-
-        lines.each_with_index do |line, idx|
-          line_num = idx + 1
-
-          # Check for START keywords first
-          if line =~ /^\s*SCHEMA\s+(\w+)/i
-            scope_stack << { type: :schema, name: $1, line: line_num }
-          end
-
-          if line =~ /^\s*FUNCTION\s+(\w+)/i
-            scope_stack << { type: :function, name: $1, line: line_num }
-          end
-
-          if line =~ /^\s*PROCEDURE\s+(\w+)/i
-            scope_stack << { type: :procedure, name: $1, line: line_num }
-          end
-
-          if line =~ /^\s*RULE\s+(\w+)/i
-            scope_stack << { type: :rule, name: $1, line: line_num }
-          end
-
-          if line =~ /^\s*ENTITY\s+(\w+)/i
-            scope_stack << { type: :entity, name: $1, line: line_num }
-          end
-
-          if line =~ /^\s*TYPE\s+(\w+)/i
-            scope_stack << { type: :type, name: $1, line: line_num }
-          end
-
-          # Check for END keywords (inline closures on same line handled here)
-          if (line =~ /END_TYPE/i) && (scope_stack.last&.dig(:type) == :type)
-            scope_stack.pop
-          end
-          if (line =~ /END_FUNCTION/i) && (scope_stack.last&.dig(:type) == :function)
-            scope_stack.pop
-          end
-          if (line =~ /END_PROCEDURE/i) && (scope_stack.last&.dig(:type) == :procedure)
-            scope_stack.pop
-          end
-          if (line =~ /END_RULE/i) && (scope_stack.last&.dig(:type) == :rule)
-            scope_stack.pop
-          end
-          if (line =~ /END_ENTITY/i) && (scope_stack.last&.dig(:type) == :entity)
-            scope_stack.pop
-          end
-          if (line =~ /END_SCHEMA/i) && (scope_stack.last&.dig(:type) == :schema)
-            scope_stack.pop
-          end
-
-          # Record the innermost scope for this line
-          scope_map[line_num] = scope_stack.last&.dig(:name)
-        end
-
-        scope_map
-      end
-
-      # O(1) scope lookup using pre-computed scope map
-      def find_containing_scope_by_name(remark_line)
-        return nil unless @scope_map
-
-        scope_name = @scope_map[remark_line]
-        return nil unless scope_name
-
-        # Find the model node for this scope
-        return nil unless @model
-
-        @model.schemas.each do |schema|
-          return schema if schema.id == scope_name
-
-          %i[functions procedures rules entities types].each do |decl_type|
-            collection = schema.public_send(decl_type)
-            next unless collection.is_a?(Array)
-
-            found = collection.find { |n| n.id == scope_name }
-            return found if found
-          end
-        end
-
-        nil
-      end
-
-      def find_node_in_scope(scope, tag)
-        return nil unless scope
-
-        collections_on(scope).each do |collection|
-          collection.each do |item|
-            next unless item.is_a?(Model::HasRemarks)
-            return item if item.id == tag
-          end
-        end
-
-        # Search inside types for enumeration items
-        types = get_collection(scope, :types)
-        types&.each do |type|
-          result = find_enumeration_item_in_type(type, tag)
-          return result if result
-        end
-
-        # Search inside statements for nested items (alias, repeat, query)
-        statements = get_collection(scope, :statements)
-        statements&.each do |stmt|
-          result = find_node_in_statement(stmt, tag)
-          return result if result
-
-          # Search inside expressions for QueryExpression (nested in assignments, etc.)
-          result = find_query_in_expression(stmt, tag)
-          return result if result
-        end
-
-        nil
-      end
-
-      def find_enumeration_item_in_type(type, tag)
-        return nil unless type
-
-        # Check if type is a Type declaration with enumeration
-        if type.is_a?(Model::Declarations::Type)
-          # Check enumeration_items on the type itself
-          type.enumeration_items&.each do |item|
-            return item if item.id == tag
-          end
-
-          # Also check underlying_type if it's an enumeration
-          ut = type.underlying_type
-          if ut.is_a?(Model::DataTypes::Enumeration) && ut.items
-            ut.items.each do |item|
-              return item if item.id == tag
-            end
-          end
-        end
-
-        nil
-      end
+      # Shared with {NodePositionIndex} via that class's own copy of the table.
+      # Two declarations rather than a cross-reference so each module is loadable
+      # on its own without forcing the other to load.
+      COLLECTION_REGISTRY = NodePositionIndex::COLLECTION_REGISTRY
 
       # Expression and statement child attributes for QueryExpression search.
       # Targeted traversal prevents over-matching on unrelated model attributes.
@@ -400,6 +44,227 @@ module Expressir
         Model::Statements::Repeat => %i[while_expression until_expression],
       }.freeze
 
+      def initialize(source)
+        @source = source
+        @attached_spans = Set.new
+        @line_map = LineMap.new(source.b)
+        @model = nil
+        @scope_resolver = nil
+        @node_index = nil
+      end
+
+      def attach(model)
+        @model = model
+        remarks = RemarkScanner.new(@source).scan
+
+        @node_index = NodePositionIndex.new(model, @line_map)
+        @scope_resolver = ScopeResolver.new(
+          source: @source,
+          model: model,
+          nodes_with_positions: @node_index.nodes,
+        )
+
+        attach_tagged_remarks(remarks)
+        attach_untagged_remarks(remarks)
+
+        # Free expensive data structures after attachment is complete.
+        @source = nil
+        @scope_resolver = nil
+        @node_index = nil
+        @line_map = nil
+
+        model
+      end
+
+      private
+
+      # ----- Tagged remark attachment -----
+
+      def attach_tagged_remarks(remarks)
+        tagged = remarks.select(&:tag)
+        return if tagged.empty?
+
+        tagged.each do |remark|
+          next if @attached_spans.include?(remark.position)
+
+          tag = remark.tag
+          target = nil
+
+          containing_scope = @scope_resolver.containing_scope_for(remark.line)
+
+          # Check if this is an informal proposition tag (IP\d+)
+          if tag.match?(/^IP\d+$/)
+            scope = containing_scope || @scope_resolver.find_by_source_text(remark.line)
+            if scope && supports_informal_propositions?(scope)
+              target = create_or_find_informal_proposition(scope, tag)
+            end
+          end
+
+          # Standard path-based lookup
+          if target.nil?
+            # Handle prefixed tags like wr:WR1, ip:IP1, ur:UR1
+            if tag.include?(":") && !tag.include?(".")
+              target = handle_prefixed_tag(tag, containing_scope, @model,
+                                           get_schema_ids(@model))
+            end
+
+            # Strategy 1: Try exact path lookup
+            if target.nil?
+              target = find_by_exact_path(@model, tag)
+            end
+
+            # Strategy 1b: For paths with dots, try with scope path prefix first
+            if target.nil? && tag.include?(".")
+              if containing_scope && function_rule_procedure?(containing_scope)
+                scope_path = build_scope_path(containing_scope)
+                if scope_path
+                  target = find_by_exact_path(@model, "#{scope_path}.#{tag}")
+                end
+              end
+
+              if target.nil?
+                schema_ids = get_schema_ids(@model)
+                schema_ids.each do |schema_id|
+                  target = find_by_exact_path(@model, "#{schema_id}.#{tag}")
+                  break if target
+                end
+              end
+            end
+
+            # Strategy 2: For simple tags, find in containing scope first
+            if target.nil? && !tag.include?(".")
+              if containing_scope
+                target = find_node_in_scope(containing_scope, tag)
+
+                if target.nil? && supports_where_rules?(containing_scope)
+                  target = find_target_in_where_clause(containing_scope, tag,
+                                                       remark.line)
+                end
+
+                if target.nil? && !function_rule_procedure?(containing_scope)
+                  schema_ids = get_schema_ids(@model)
+                  schema_ids.each do |schema_id|
+                    target = find_by_exact_path(@model, "#{schema_id}.#{tag}")
+                    break if target
+                  end
+                end
+              else
+                schema_ids = get_schema_ids(@model)
+                schema_ids.each do |schema_id|
+                  target = find_by_exact_path(@model, "#{schema_id}.#{tag}")
+                  break if target
+                end
+              end
+            end
+
+            # Strategy 3: Create implicit item for qualified paths only
+            if target.nil? && tag.include?(".")
+              if containing_scope && function_rule_procedure?(containing_scope)
+                scope_path = build_scope_path(containing_scope)
+                if scope_path
+                  target = create_implicit_remark_item(@model, "#{scope_path}.#{tag}",
+                                                       get_schema_ids(@model))
+                end
+              end
+              if target.nil?
+                target = create_implicit_remark_item(@model, tag,
+                                                     get_schema_ids(@model))
+              end
+            end
+
+            # Strategy 4: For simple tags at schema level, create implicit item
+            if target.nil? && !tag.include?(".")
+              schema_ids = get_schema_ids(@model)
+              if schema_ids.any?
+                target = create_implicit_remark_item_at_schema(@model, tag,
+                                                               schema_ids.first)
+              end
+            end
+          end
+
+          if target
+            add_remark(target, remark.text, format: remark.format, tag: remark.tag)
+            @attached_spans << remark.position
+          end
+        end
+      end
+
+      # ----- Untagged remark attachment -----
+
+      def attach_untagged_remarks(remarks)
+        untagged = remarks.reject(&:tag)
+        return unless untagged.any?
+
+        untagged.each do |remark|
+          next if @attached_spans.include?(remark.position)
+
+          line_content = line_content_for(remark.line)
+          if end_scope_line?(line_content)
+            matched_node = @node_index.node_for_end_scope_at(remark.line, line_content)
+            if matched_node
+              add_remark(matched_node, remark.text, format: remark.format, tag: nil)
+              @attached_spans << remark.position
+              next
+            end
+          end
+
+          matched_node = @node_index.nearest_node_to(remark.line)
+          if matched_node
+            add_remark(matched_node, remark.text, format: remark.format, tag: nil)
+            @attached_spans << remark.position
+          end
+        end
+      end
+
+      def end_scope_line?(line_content)
+        line_content =~ /END_(SCHEMA|ENTITY|TYPE|FUNCTION|PROCEDURE|RULE)/i
+      end
+
+      # ----- Tag resolution (within a scope) -----
+
+      def find_node_in_scope(scope, tag)
+        return nil unless scope
+
+        collections_on(scope).each do |collection|
+          collection.each do |item|
+            next unless item.is_a?(Model::HasRemarks)
+            return item if item.id == tag
+          end
+        end
+
+        types = get_collection(scope, :types)
+        types&.each do |type|
+          result = find_enumeration_item_in_type(type, tag)
+          return result if result
+        end
+
+        statements = get_collection(scope, :statements)
+        statements&.each do |stmt|
+          result = find_node_in_statement(stmt, tag)
+          return result if result
+
+          result = find_query_in_expression(stmt, tag)
+          return result if result
+        end
+
+        nil
+      end
+
+      def find_enumeration_item_in_type(type, tag)
+        return nil unless type
+        return nil unless type.is_a?(Model::Declarations::Type)
+
+        type.enumeration_items&.each do |item|
+          return item if item.id == tag
+        end
+
+        ut = type.underlying_type
+        return nil unless ut.is_a?(Model::DataTypes::Enumeration) && ut.items
+
+        ut.items.each { |item| return item if item.id == tag }
+        nil
+      end
+
       def find_query_in_expression(node, tag, visited = Set.new)
         return nil unless node
         return nil unless node.is_a?(Model::ModelElement)
@@ -407,9 +272,7 @@ module Expressir
 
         visited.add(node.object_id)
 
-        if node.is_a?(Model::Expressions::QueryExpression) && node.id == tag
-          return node
-        end
+        return node if node.is_a?(Model::Expressions::QueryExpression) && node.id == tag
 
         attrs = EXPRESSION_CHILDREN[node.class]
         return nil unless attrs
@@ -446,7 +309,6 @@ module Expressir
         prefix, id = tag.split(":")
         return nil unless id
 
-        # Determine collection based on prefix
         collection_attr = case prefix.downcase
                           when "wr" then :where_rules
                           when "ip" then :informal_propositions
@@ -454,14 +316,12 @@ module Expressir
                           end
         return nil unless collection_attr
 
-        # First try to find in containing scope
         collection = get_collection(containing_scope, collection_attr)
         if collection
           found = collection.find { |item| item.is_a?(Model::ModelElement) && item.id == id }
           return found if found
         end
 
-        # Fallback: try to find by full path
         schema_ids.each do |schema_id|
           full_path = "#{schema_id}.#{tag.tr(':', '.')}"
           found = safe_find(model, full_path)
@@ -471,36 +331,36 @@ module Expressir
         nil
       end
 
-      # Find target for remarks inside WHERE clauses
+      # Find target for remarks inside WHERE clauses by scanning source lines
+      # for `WHERE <id>:` patterns. Lives here (not in ScopeResolver) because
+      # it's about WHERE-rule membership, not scope membership.
       def find_target_in_where_clause(scope, tag, remark_line)
         return nil unless supports_where_rules?(scope)
 
         where_rules = get_collection(scope, :where_rules)
         return nil unless where_rules&.any?
 
-        # Search source text for WHERE clause containing this remark
-        lines = source_lines
+        lines = source_lines_for_where_clause
 
         where_rules.each do |wr|
           next unless wr.id
 
-          # Find the WHERE rule declaration
           lines.each_with_index do |line, idx|
             line_num = idx + 1
             next unless line_num < remark_line
 
-            # Look for "WHERE {id}:" pattern
-            # Check if remark is within a few lines after this WHERE declaration
-            if (line =~ /^\s*WHERE\s+#{Regexp.escape(wr.id)}\s*:/i) && remark_line.between?(
-              line_num, line_num + 5
-            )
-              # Found the WHERE rule - create remark item inside it
+            if (line =~ /^\s*WHERE\s+#{Regexp.escape(wr.id)}\s*:/i) && remark_line.between?(line_num, line_num + 5)
               return create_remark_item(wr, tag)
             end
           end
         end
 
         nil
+      end
+
+      def source_lines_for_where_clause
+        # @source is set for the duration of `attach`; freed at the end.
+        @source.lines
       end
 
       def find_node_in_statement(stmt, tag)
@@ -515,15 +375,6 @@ module Expressir
         nil
       end
 
-      def find_containing_scope(remark_line, nodes_with_positions)
-        # First try scope map (O(1) once built)
-        scope = find_containing_scope_by_name(remark_line)
-        return scope if scope
-
-        # Fallback to position-based detection
-        find_containing_scope_position(remark_line, nodes_with_positions)
-      end
-
       def build_scope_path(node)
         return nil unless node
 
@@ -535,7 +386,6 @@ module Expressir
             parts.unshift(current.id)
           end
 
-          # Stop at schema level
           break if current.is_a?(Model::Declarations::Schema)
 
           current = current.parent
@@ -544,113 +394,31 @@ module Expressir
         parts.empty? ? nil : parts.join(".")
       end
 
-      def find_scope_by_source_text(remark_line)
-        # Search backwards from remark_line for containing scope
-        lines = source_lines
-
-        # Find the entity/type/rule that contains this line
-        entity_start = nil
-        type_start = nil
-        rule_start = nil
-        current_entity = nil
-        current_type = nil
-        current_rule = nil
-
-        lines.each_with_index do |line, idx|
-          line_num = idx + 1
-
-          case line
-          when /^\s*ENTITY\s+(\w+)/i
-            entity_start = line_num
-            current_entity = $1
-          when /^\s*END_ENTITY/i
-            if entity_start && remark_line >= entity_start && remark_line <= line_num
-              # Found containing entity
-              return find_node_by_type_and_name(Model::Declarations::Entity,
-                                                current_entity)
-            end
-
-            entity_start = nil
-            current_entity = nil
-          when /^\s*TYPE\s+(\w+)/i
-            type_start = line_num
-            current_type = $1
-          when /^\s*END_TYPE/i
-            if type_start && remark_line >= type_start && remark_line <= line_num
-              # Found containing type
-              return find_node_by_type_and_name(Model::Declarations::Type,
-                                                current_type)
-            end
-
-            type_start = nil
-            current_type = nil
-          when /^\s*RULE\s+(\w+)/i
-            rule_start = line_num
-            current_rule = $1
-          when /^\s*END_RULE/i
-            if rule_start && remark_line >= rule_start && remark_line <= line_num
-              # Found containing rule
-              return find_node_by_type_and_name(Model::Declarations::Rule,
-                                                current_rule)
-            end
-
-            rule_start = nil
-            current_rule = nil
-          end
-        end
-
-        nil
-      end
-
-      COLLECTION_ACCESSOR = {
-        Expressir::Model::Declarations::Entity => lambda(&:entities),
-        Expressir::Model::Declarations::Type => lambda(&:types),
-        Expressir::Model::Declarations::Rule => lambda(&:rules),
-      }.freeze
-
-      def find_node_by_type_and_name(node_class, name)
-        return nil unless @model && name
-
-        accessor = COLLECTION_ACCESSOR[node_class]
-        return nil unless accessor
-
-        @model.schemas.each do |schema|
-          found = accessor.call(schema)&.find { |n| n.id == name }
-          return found if found
-        end
-
-        nil
-      end
+      # ----- Path-based lookup -----
 
       def find_by_exact_path(model, path)
         return nil unless path
-
-        # Only Repository and ExpFile support path-based find
         return nil unless repository?(model) || exp_file?(model)
 
-        # Try original path
         result = safe_find(model, path)
         return result if result
 
-        # Try with colon converted to dot
         normalized = path.tr(":", ".")
         normalized == path ? nil : safe_find(model, normalized)
       end
 
+      # ----- Target creation -----
+
       def create_implicit_remark_item_at_schema(model, item_id, schema_id)
-        # Only Repository and ExpFile support schema lookup
         return nil unless repository?(model) || exp_file?(model)
 
         schema = safe_find(model, schema_id)
         return nil unless schema.is_a?(Model::Declarations::Schema)
 
-        # Handle informal propositions (IP\d+ pattern) - only if schema supports it
-        # Note: Schema doesn't have informal_propositions, so this will create a remark_item instead
         if item_id.match?(/^IP\d+$/) && supports_informal_propositions?(schema)
           return create_or_find_informal_proposition(schema, item_id)
         end
 
-        # Handle remark items
         return nil unless supports_remark_items?(schema)
 
         existing = schema.remark_items&.find { |ri| ri.id == item_id }
@@ -662,19 +430,16 @@ module Expressir
       def create_implicit_remark_item(model, path, schema_ids = [])
         return nil unless repository?(model) || exp_file?(model)
 
-        # Normalize path (handle "ip:IP1" format)
         clean_path = normalize_path(path)
         parts = clean_path.split(".")
         return nil if parts.length < 2
 
-        # Find the deepest existing parent and create item there
         (parts.length - 1).downto(1) do |i|
           parent_path = parts[0...i].join(".")
           item_id = parts[i]
 
           parent = safe_find(model, parent_path)
 
-          # Try with schema prefix if not found
           if parent.nil? && schema_ids.any?
             schema_ids.each do |schema_id|
               parent = safe_find(model, "#{schema_id}.#{parent_path}")
@@ -698,12 +463,10 @@ module Expressir
       end
 
       def create_item_at_parent(parent, item_id)
-        # Handle informal propositions
         if item_id.match?(/^IP\d+$/) && supports_informal_propositions?(parent)
           return create_or_find_informal_proposition(parent, item_id)
         end
 
-        # Handle remark items
         return nil unless supports_remark_items?(parent)
 
         existing = parent.remark_items&.find { |ri| ri.id == item_id }
@@ -713,7 +476,6 @@ module Expressir
       end
 
       def create_or_find_informal_proposition(parent, id)
-        # Only Entity, Rule, Type, and InformalPropositionRule have informal_propositions
         return nil unless supports_informal_propositions?(parent)
 
         existing = parent.informal_propositions&.find { |ip| ip.id == id }
@@ -725,15 +487,12 @@ module Expressir
         parent.informal_propositions << ip
         safe_reset_children_by_id(parent)
 
-        # Also create a RemarkItem inside the InformalPropositionRule
-        # This is the expected structure for informal proposition remarks
         remark_item = Model::Declarations::RemarkItem.new(id: id)
         remark_item.parent = ip
         ip.remark_items ||= []
         ip.remark_items << remark_item
         safe_reset_children_by_id(ip)
 
-        # Return the remark_item so remarks are added to it
         remark_item
       end
 
@@ -746,84 +505,19 @@ module Expressir
         item
       end
 
-      def attach_untagged_remarks(remarks, nodes_with_positions)
-        untagged = remarks.reject(&:tag)
-        return unless untagged.any?
+      # ----- Remark storage -----
 
-        untagged.each do |remark|
-          next if @attached_spans.include?(remark.position)
-
-          if end_scope_line?(remark.line)
-            matched_node = find_node_for_end_scope_remark(remark,
-                                                          nodes_with_positions)
-            if matched_node
-              add_remark(matched_node, remark.text, format: remark.format, tag: nil)
-              @attached_spans << remark.position
-              next
-            end
-          end
-
-          matched_node = find_nearest_node(remark, nodes_with_positions)
-          if matched_node
-            add_remark(matched_node, remark.text, format: remark.format, tag: nil)
-            @attached_spans << remark.position
-          end
-        end
-      end
-
-      def end_scope_line?(line_num)
-        line = get_line_content(line_num)
-        line =~ /END_(SCHEMA|ENTITY|TYPE|FUNCTION|PROCEDURE|RULE)/i
-      end
-
-      def get_line_content(line_num)
-        lines = source_lines
-        return "" if line_num < 1 || line_num > lines.length
-
-        lines[line_num - 1]
-      end
-
-      def find_node_for_end_scope_remark(remark, nodes)
-        line_content = get_line_content(remark.line)
-
-        node_type = case line_content
-                    when /END_SCHEMA/i then Model::Declarations::Schema
-                    when /END_ENTITY/i then Model::Declarations::Entity
-                    when /END_TYPE/i then Model::Declarations::Type
-                    when /END_FUNCTION/i then Model::Declarations::Function
-                    when /END_PROCEDURE/i then Model::Declarations::Procedure
-                    when /END_RULE/i then Model::Declarations::Rule
-                    end
-
-        return nil unless node_type
-
-        matching_nodes = nodes.select do |n|
-          n[:node].is_a?(node_type) &&
-            (n[:end_line] == remark.line ||
-             (n[:end_line] && n[:end_line] <= remark.line && n[:end_line] >= remark.line - 2))
-        end
-
-        matching_nodes.first&.dig(:node) || find_node_by_type(nodes, node_type)
-      end
-
-      def find_node_by_type(nodes, node_type)
-        nodes.find { |n| n[:node].is_a?(node_type) }&.dig(:node)
-      end
-
-      def add_remark(node, text, format: "tail", tag: nil)
+      def add_remark(node, text, format: Model::RemarkFormat::TAIL, tag: nil)
         return unless node
         return unless node.is_a?(Model::ModelElement)
 
-        # Only add remarks to nodes that support them
         if supports_remarks?(node)
-          # Always add to remarks attribute (for types that have it)
           if node_has_remarks?(node)
             node.remarks ||= []
             node.remarks << text
           end
 
           if tag.nil?
-            # Untagged remark: store in untagged_remarks
             remark_info = Model::RemarkInfo.new(text: text, format: format)
             node.untagged_remarks ||= []
             node.untagged_remarks << remark_info
@@ -831,7 +525,8 @@ module Expressir
         end
       end
 
-      # All ModelElement subclasses have untagged_remarks from ModelElement
+      # ----- Type predicates -----
+
       def supports_remarks?(obj)
         obj.is_a?(Model::ModelElement)
       end
@@ -840,180 +535,16 @@ module Expressir
         obj.is_a?(Model::HasRemarks)
       end
 
-      # Types that include HasRemarkItems can have remark_items
       def supports_remark_items?(obj)
         obj.is_a?(Model::HasRemarkItems)
       end
 
-      def collect_nodes_with_positions(node, result, visited = Set.new)
-        return unless node
-        return if visited.include?(node.object_id)
-
-        visited.add(node.object_id)
-
-        if node.is_a?(Model::ModelElement) && node.source
-          # Use stored source_offset from parser
-          # The parser always provides this via Slice#offset
-          if node.source_offset
-            pos = node.source_offset
-            # Validate offset: native parser returns 0 for leaf nodes (WhereRule)
-            # where it can't determine the actual position. These have short
-            # expression-like source ("TRUE;") that doesn't appear at file start.
-            # Container nodes (Schema, Entity, Type) have declaration-like source
-            # that either starts at position 0 legitimately or is clearly valid.
-            valid = pos.positive?
-            if !valid && pos.zero? && node.source
-              src = node.source.to_s
-              # Accept position=0 if source is a declaration keyword line
-              valid = src.start_with?("SCHEMA", "ENTITY", "TYPE", "FUNCTION",
-                                      "PROCEDURE", "RULE", "CONSTANT", "VARIABLE",
-                                      "USE", "REFERENCE", "END_SCHEMA", "END_ENTITY",
-                                      "END_TYPE", "END_FUNCTION", "END_PROCEDURE",
-                                      "END_RULE", "END_CONSTANT", "END_VARIABLE")
-            end
-            if valid
-              line = get_line_number(pos)
-              source_end_line = get_line_number(pos + node.source.length)
-
-              # For container nodes, use the maximum end_line from children
-              # This is needed because source.length only covers the declaration, not the body
-              children_end_line = calculate_children_end_line(node)
-              end_line = [source_end_line,
-                          children_end_line].compact.max || source_end_line
-
-              result << {
-                node: node,
-                position: pos,
-                line: line,
-                end_line: end_line,
-              }
-            else
-              # Invalid offset — treat as unknown position
-              result << { node: node, position: nil, line: nil, end_line: nil }
-            end
-          else
-            # No source_offset available - should not happen if parser provides Slice
-            result << { node: node, position: nil, line: nil, end_line: nil }
-          end
-        else
-          result << { node: node, position: nil, line: nil, end_line: nil }
-        end
-
-        collect_children(node, result, visited)
+      def supports_informal_propositions?(obj)
+        obj.is_a?(Model::HasInformalPropositions)
       end
 
-      # Calculate the end line from all children of a node
-      # This is needed for container nodes like schemas, entities, etc.
-      # where source.length only covers the declaration, not the body
-      def calculate_children_end_line(node)
-        children_end_lines = []
-
-        # Check computed children (Schema, ExpFile have a children method)
-        if node.is_a?(Model::Declarations::Schema)
-          Array(node.children).each do |child|
-            if child.is_a?(Model::ModelElement) && child.source_offset && child.source
-              children_end_lines << get_line_number(child.source_offset + child.source.length)
-            end
-          end
-        end
-
-        # Visit declared collections from type registry
-        collections_on(node).each do |collection|
-          collection.each do |child|
-            if child.is_a?(Model::ModelElement) && child.source_offset && child.source
-              children_end_lines << get_line_number(child.source_offset + child.source.length)
-            end
-          end
-        end
-
-        children_end_lines.max
-      end
-
-      def collect_children(node, result, visited)
-        if node.is_a?(Model::Declarations::Schema)
-          Array(node.children).each do |child|
-            collect_nodes_with_positions(child, result, visited)
-          end
-        end
-
-        collections_on(node).each do |collection|
-          collection.each do |item|
-            collect_nodes_with_positions(item, result, visited)
-          end
-        end
-      end
-
-      # Build sorted nodes_with_positions ONCE for both tagged and untagged remark passes.
-      # This merges the two separate tree walks into one, cutting node visits in half.
-      def build_sorted_nodes_with_positions(model)
-        nodes_with_positions = []
-        collect_nodes_with_positions(model, nodes_with_positions)
-        # Stable sort: nil positions last, ties broken by insertion order
-        nodes_with_positions.sort_by!.with_index { |n, i| [n[:position] || Float::INFINITY, i] }
-        nodes_with_positions
-      end
-
-      def find_nearest_node(remark, nodes)
-        remark_line = remark.line
-
-        # For tail remarks, prefer nodes that START on the same line
-        # This handles cases like: "attr : STRING; -- tail remark"
-        # Exclude Repository and Cache as they are not semantic scopes
-        same_start_line = nodes.select do |n|
-          n[:line] == remark_line &&
-            !repository?(n[:node]) && !cache?(n[:node])
-        end
-        return same_start_line.last[:node] if same_start_line.any?
-
-        # Also check nodes that END on the same line
-        same_end_line = nodes.select do |n|
-          n[:end_line] == remark_line &&
-            !repository?(n[:node]) && !cache?(n[:node])
-        end
-        return same_end_line.last[:node] if same_end_line.any?
-
-        # Find the node that CONTAINS this remark line
-        # This handles preamble remarks and embedded remarks
-        # Exclude Repository and Cache as they are not semantic scopes
-        # But include ExpFile for file-level preamble remarks
-        containing = nodes.select do |n|
-          n[:line] && n[:end_line] && n[:line] <= remark_line && n[:end_line] >= remark_line &&
-            !repository?(n[:node]) && !cache?(n[:node])
-        end
-
-        if containing.any?
-          # Prefer ExpFile for preamble remarks (before first schema)
-          # Otherwise return the most specific (smallest) containing node
-          exp_file_node = containing.find { |n| exp_file?(n[:node]) }
-          # If this is a preamble remark (before first schema line), use ExpFile
-          if exp_file_node
-            first_schema_line = exp_file_node[:node].schemas&.first&.source_offset
-            if first_schema_line && remark_line < get_line_number(first_schema_line)
-              return exp_file_node[:node]
-            end
-          end
-          # Sort by span size and return the smallest
-          containing.min_by { |n| n[:end_line] - n[:line] }[:node]
-        else
-          # Fallback: find the last node that ends before this line
-          before = nodes.select do |n|
-            n[:end_line] && n[:end_line] < remark_line &&
-              !repository?(n[:node]) && !cache?(n[:node])
-          end
-          before.max_by { |n| n[:end_line] }[:node] if before.any?
-        end
-      end
-
-      # Type checking helper methods
-
-      def get_schema_ids(model)
-        if repository?(model)
-          model.schemas.filter_map(&:id)
-        elsif exp_file?(model)
-          model.schemas.filter_map(&:id)
-        else
-          []
-        end
+      def supports_where_rules?(obj)
+        obj.is_a?(Model::HasWhereRules)
       end
 
       def repository?(obj)
@@ -1028,13 +559,15 @@ module Expressir
         obj.is_a?(Model::Cache)
       end
 
-      def supports_informal_propositions?(obj)
-        obj.is_a?(Model::HasInformalPropositions)
+      def get_schema_ids(model)
+        if repository?(model) || exp_file?(model)
+          model.schemas.filter_map(&:id)
+        else
+          []
+        end
       end
 
-      def supports_where_rules?(obj)
-        obj.is_a?(Model::HasWhereRules)
-      end
+      # ----- Collection access -----
 
       # Type-driven collection access — returns all collections for a node's type.
       def collections_on(node)
@@ -1055,6 +588,8 @@ module Expressir
         collection if collection.is_a?(Array)
       end
 
+      # ----- Helpers -----
+
       def safe_find(model, path)
         return nil unless model
 
@@ -1068,6 +603,13 @@ module Expressir
         return unless obj.is_a?(Model::ScopeContainer)
 
         obj.reset_children_by_id
+      end
+
+      def line_content_for(line_num)
+        lines = source_lines_for_where_clause
+        return "" if line_num < 1 || line_num > lines.length
+
+        lines[line_num - 1]
       end
     end
   end

--- a/lib/expressir/express/remark_scanner.rb
+++ b/lib/expressir/express/remark_scanner.rb
@@ -24,21 +24,17 @@ module Expressir
       # Immutable value object describing a single extracted remark.
       Remark = Struct.new(:position, :line, :text, :tag, :format, keyword_init: true) do
         def tail?
-          format == TAIL_FORMAT
+          format == Model::RemarkFormat::TAIL
         end
 
         def embedded?
-          format == EMBEDDED_FORMAT
+          format == Model::RemarkFormat::EMBEDDED
         end
 
         def tagged?
           !tag.nil? && !tag.empty?
         end
       end
-
-      # Format discriminator values.
-      TAIL_FORMAT = "tail"
-      EMBEDDED_FORMAT = "embedded"
 
       # Lexical markers recognised by EXPRESS.
       TAIL_MARKER = "--"
@@ -142,7 +138,7 @@ module Expressir
           line: line,
           text: content,
           tag: tag,
-          format: TAIL_FORMAT,
+          format: Model::RemarkFormat::TAIL,
         )
       end
 
@@ -154,7 +150,7 @@ module Expressir
           line: line,
           text: content,
           tag: tag,
-          format: EMBEDDED_FORMAT,
+          format: Model::RemarkFormat::EMBEDDED,
         )
       end
 

--- a/lib/expressir/express/scope_resolver.rb
+++ b/lib/expressir/express/scope_resolver.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module Expressir
+  module Express
+    # Resolves the containing scope for a remark line.
+    #
+    # One interface (`containing_scope_for`), four strategies behind it:
+    #   1. O(1) lookup via a precomputed line→scope-name map
+    #   2. O(n) position-based fallback against the node index
+    #   3. Source-text scan for entity/type/rule boundaries
+    #   4. Schema-wide search by name
+    #
+    # Extracted from RemarkAttacher to deepen the seam: scope lookup is the
+    # only concern here, so changes to scope-detection heuristics land in
+    # one module and the attacher stops carrying the how.
+    class ScopeResolver
+      # Match declarations of the scopes we track.
+      SCOPE_OPEN_PATTERNS = {
+        Model::Declarations::Schema => /^\s*SCHEMA\s+(\w+)/i,
+        Model::Declarations::Function => /^\s*FUNCTION\s+(\w+)/i,
+        Model::Declarations::Procedure => /^\s*PROCEDURE\s+(\w+)/i,
+        Model::Declarations::Rule => /^\s*RULE\s+(\w+)/i,
+        Model::Declarations::Entity => /^\s*ENTITY\s+(\w+)/i,
+        Model::Declarations::Type => /^\s*TYPE\s+(\w+)/i,
+      }.freeze
+
+      SCOPE_CLOSE_PATTERNS = {
+        Model::Declarations::Schema => /END_SCHEMA/i,
+        Model::Declarations::Function => /END_FUNCTION/i,
+        Model::Declarations::Procedure => /END_PROCEDURE/i,
+        Model::Declarations::Rule => /END_RULE/i,
+        Model::Declarations::Entity => /END_ENTITY/i,
+        Model::Declarations::Type => /END_TYPE/i,
+      }.freeze
+
+      # Map scope node class → schema-level collection accessor on Schema.
+      SCHEMA_COLLECTION_ACCESSOR = {
+        Model::Declarations::Entity => lambda(&:entities),
+        Model::Declarations::Type => lambda(&:types),
+        Model::Declarations::Rule => lambda(&:rules),
+      }.freeze
+
+      def initialize(source:, model:, nodes_with_positions:)
+        @source = source
+        @model = model
+        @nodes_with_positions = nodes_with_positions
+        @scope_map = nil
+      end
+
+      # Returns the innermost Model::ScopeContainer whose source span contains
+      # the given 1-based remark line, or nil if none is found.
+      def containing_scope_for(remark_line)
+        scope = find_by_name(remark_line)
+        scope ||= find_by_position(remark_line)
+        scope
+      end
+
+      # Source-text fallback: scan backwards from remark_line for the
+      # entity/type/rule declaration that contains it. Used by the attacher
+      # when both name- and position-based lookup miss (e.g. for IP tags
+      # whose target is a Type/Entity/Rule declared on a previous line).
+      def find_by_source_text(remark_line)
+        entity_state = { line: nil, name: nil }
+        type_state = { line: nil, name: nil }
+        rule_state = { line: nil, name: nil }
+
+        @source.lines.each_with_index do |line, idx|
+          line_num = idx + 1
+
+          case line
+          when /^\s*ENTITY\s+(\w+)/i
+            entity_state = { line: line_num, name: $1 }
+          when /^\s*END_ENTITY/i
+            return find_in_schema(Model::Declarations::Entity, entity_state[:name]) if span_contains?(entity_state, remark_line, line_num)
+
+            entity_state = { line: nil, name: nil }
+          when /^\s*TYPE\s+(\w+)/i
+            type_state = { line: line_num, name: $1 }
+          when /^\s*END_TYPE/i
+            return find_in_schema(Model::Declarations::Type, type_state[:name]) if span_contains?(type_state, remark_line, line_num)
+
+            type_state = { line: nil, name: nil }
+          when /^\s*RULE\s+(\w+)/i
+            rule_state = { line: line_num, name: $1 }
+          when /^\s*END_RULE/i
+            return find_in_schema(Model::Declarations::Rule, rule_state[:name]) if span_contains?(rule_state, remark_line, line_num)
+
+            rule_state = { line: nil, name: nil }
+          end
+        end
+
+        nil
+      end
+
+      private
+
+      def span_contains?(state, remark_line, end_line)
+        state[:line] && remark_line >= state[:line] && remark_line <= end_line
+      end
+
+      # --- Strategy 1: precomputed line → scope-name map ---
+
+      def find_by_name(remark_line)
+        scope_name = scope_map[remark_line]
+        return nil unless scope_name
+        return nil unless @model
+
+        @model.schemas.each do |schema|
+          return schema if schema.id == scope_name
+
+          %i[functions procedures rules entities types].each do |decl_type|
+            collection = schema.public_send(decl_type)
+            next unless collection.is_a?(Array)
+
+            found = collection.find { |n| n.id == scope_name }
+            return found if found
+          end
+        end
+
+        nil
+      end
+
+      # Lazily build, on first lookup, the line → scope-name table.
+      # O(file_lines) scan; subsequent lookups are O(1).
+      def scope_map
+        @scope_map ||= build_scope_map
+      end
+
+      def build_scope_map
+        lines = @source.lines
+        map = {}
+        return map if lines.empty?
+
+        stack = [] # array of { type: Class, name: String }
+
+        lines.each_with_index do |line, idx|
+          line_num = idx + 1
+
+          SCOPE_OPEN_PATTERNS.each do |klass, pattern|
+            stack << { type: klass, name: $1 } if line =~ pattern
+          end
+
+          SCOPE_CLOSE_PATTERNS.each do |klass, pattern|
+            next unless line&.match?(pattern)
+            next unless stack.last && stack.last[:type] == klass
+
+            stack.pop
+          end
+
+          map[line_num] = stack.last&.dig(:name)
+        end
+
+        map
+      end
+
+      # --- Strategy 2: position-based fallback against the node index ---
+
+      def find_by_position(remark_line)
+        containing = @nodes_with_positions.select do |n|
+          n[:line] && n[:end_line] &&
+            remark_line >= n[:line] && remark_line <= n[:end_line] &&
+            !n[:node].is_a?(Model::Repository) && !n[:node].is_a?(Model::Cache)
+        end
+
+        containing.reverse_each do |n|
+          return n[:node] if n[:node].is_a?(Model::ScopeContainer)
+        end
+
+        nil
+      end
+
+      # --- Schema-wide name search (used by source-text fallback) ---
+
+      def find_in_schema(node_class, name)
+        return nil unless @model && name
+
+        accessor = SCHEMA_COLLECTION_ACCESSOR[node_class]
+        return nil unless accessor
+
+        @model.schemas.each do |schema|
+          found = accessor.call(schema)&.find { |n| n.id == name }
+          return found if found
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/expressir/express/scope_resolver.rb
+++ b/lib/expressir/express/scope_resolver.rb
@@ -98,6 +98,11 @@ module Expressir
         state[:line] && remark_line >= state[:line] && remark_line <= end_line
       end
 
+      # Schema-level collections searched when resolving a scope name to a
+      # model node. Lifted out of the loop so the array isn't reallocated
+      # per iteration.
+      SCHEMA_DECL_COLLECTIONS = %i[functions procedures rules entities types].freeze
+
       # --- Strategy 1: precomputed line → scope-name map ---
 
       def find_by_name(remark_line)
@@ -108,7 +113,7 @@ module Expressir
         @model.schemas.each do |schema|
           return schema if schema.id == scope_name
 
-          %i[functions procedures rules entities types].each do |decl_type|
+          SCHEMA_DECL_COLLECTIONS.each do |decl_type|
             collection = schema.public_send(decl_type)
             next unless collection.is_a?(Array)
 

--- a/lib/expressir/express/scope_resolver.rb
+++ b/lib/expressir/express/scope_resolver.rb
@@ -40,6 +40,11 @@ module Expressir
         Model::Declarations::Rule => lambda(&:rules),
       }.freeze
 
+      # Schema-level collections searched when resolving a scope name to a
+      # model node. Lifted out of the loop so the array isn't reallocated
+      # per iteration.
+      SCHEMA_DECL_COLLECTIONS = %i[functions procedures rules entities types].freeze
+
       def initialize(source:, model:, nodes_with_positions:)
         @source = source
         @model = model
@@ -97,11 +102,6 @@ module Expressir
       def span_contains?(state, remark_line, end_line)
         state[:line] && remark_line >= state[:line] && remark_line <= end_line
       end
-
-      # Schema-level collections searched when resolving a scope name to a
-      # model node. Lifted out of the loop so the array isn't reallocated
-      # per iteration.
-      SCHEMA_DECL_COLLECTIONS = %i[functions procedures rules entities types].freeze
 
       # --- Strategy 1: precomputed line → scope-name map ---
 

--- a/lib/expressir/model.rb
+++ b/lib/expressir/model.rb
@@ -1,10 +1,16 @@
 # lib/expressir/model.rb
 
-# Load marker modules for type checking
-require_relative "model/concerns"
-
 module Expressir
   module Model
+    # Marker modules — autoload the same concerns.rb file from each name.
+    # The first reference triggers the load; the file defines all six markers.
+    autoload :HasId, "#{__dir__}/model/concerns"
+    autoload :HasRemarkItems, "#{__dir__}/model/concerns"
+    autoload :HasRemarks, "#{__dir__}/model/concerns"
+    autoload :ScopeContainer, "#{__dir__}/model/concerns"
+    autoload :HasInformalPropositions, "#{__dir__}/model/concerns"
+    autoload :HasWhereRules, "#{__dir__}/model/concerns"
+
     autoload :ModelElement, "#{__dir__}/model/model_element"
     autoload :Cache, "#{__dir__}/model/cache"
     autoload :ExpFile, "#{__dir__}/model/exp_file"
@@ -12,6 +18,7 @@ module Expressir
     autoload :Repository, "#{__dir__}/model/repository"
     autoload :RepositoryValidator, "#{__dir__}/model/repository_validator"
     autoload :DependencyResolver, "#{__dir__}/model/dependency_resolver"
+    autoload :RemarkFormat, "#{__dir__}/model/remark_format"
     autoload :RemarkInfo, "#{__dir__}/model/remark_info"
     autoload :InterfaceValidator, "#{__dir__}/model/interface_validator"
     autoload :SearchEngine, "#{__dir__}/model/search_engine"

--- a/lib/expressir/model/remark_format.rb
+++ b/lib/expressir/model/remark_format.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Expressir
+  module Model
+    # Single source of truth for the remark-format vocabulary.
+    #
+    # Reference: ISO 10303-11 §7.1.6 defines exactly two remark forms:
+    # the tail remark (`-- ... \n`) and the embedded remark (`(* ... *)`).
+    # Both the model (RemarkInfo) and the express-side scanner/attacher
+    # reference these constants instead of bare string literals, so a
+    # rename or extension lands in one place.
+    module RemarkFormat
+      TAIL = "tail"
+      EMBEDDED = "embedded"
+    end
+  end
+end

--- a/lib/expressir/model/remark_info.rb
+++ b/lib/expressir/model/remark_info.rb
@@ -5,19 +5,19 @@ module Expressir
     # Can include optional tags for associating remarks with specific items
     class RemarkInfo < Lutaml::Model::Serializable
       attribute :text, :string
-      attribute :format, :string, default: "embedded" # 'tail' or 'embedded'
+      attribute :format, :string, default: RemarkFormat::EMBEDDED
       attribute :tag, :string # optional remark tag like "entity.attr"
 
       # Check if this is a tail remark
       # @return [Boolean] True if format is 'tail'
       def tail?
-        format == "tail"
+        format == RemarkFormat::TAIL
       end
 
       # Check if this is an embedded remark
       # @return [Boolean] True if format is 'embedded'
       def embedded?
-        format == "embedded"
+        format == RemarkFormat::EMBEDDED
       end
 
       # Check if this remark has a tag

--- a/spec/expressir/express/node_position_index_spec.rb
+++ b/spec/expressir/express/node_position_index_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Expressir::Express::NodePositionIndex do
+  let(:source) do
+    <<~EXP
+      SCHEMA demo;
+      ENTITY person;
+        name : STRING;
+      END_ENTITY;
+      END_SCHEMA;
+    EXP
+  end
+
+  let(:exp_file) { Expressir::Express::Parser.from_exp(source) }
+  let(:line_map) { Expressir::Express::LineMap.new(source.b) }
+  let(:index) { described_class.new(exp_file, line_map) }
+
+  it "collects every model element with a source span" do
+    expect(index.nodes).not_to be_empty
+    classes = index.nodes.map { |n| n[:node].class }.uniq
+    expect(classes).to include(Expressir::Model::Declarations::Schema)
+    expect(classes).to include(Expressir::Model::Declarations::Entity)
+  end
+
+  it "returns nodes sorted by byte position" do
+    positions = index.nodes.filter_map { |n| n[:position] }
+    expect(positions).to eq(positions.sort)
+  end
+
+  it "nearest_node_to prefers a node starting on the same line" do
+    # Tail-remark semantics: a remark on the same line as a declaration
+    # attaches to that declaration, not to the containing scope.
+    name_line = source.lines.index { |l| l.include?("name : STRING") } + 1
+    node = index.nearest_node_to(name_line)
+    expect(node).to be_a(Expressir::Model::Declarations::Attribute)
+  end
+
+  it "nearest_node_to falls back to the containing scope when no node starts on the line" do
+    # A line inside the entity body but with no declaration on it should
+    # resolve to the smallest containing scope.
+    entity_inner_line = source.lines.index { |l| l.include?("ENTITY person") } + 1
+    node = index.nearest_node_to(entity_inner_line)
+    expect(node).to be_a(Expressir::Model::Declarations::Entity)
+  end
+
+  it "node_for_end_scope_at returns the schema on its END_SCHEMA line" do
+    end_line = source.lines.index { |l| l.include?("END_SCHEMA") } + 1
+    content = source.lines[end_line - 1]
+    node = index.node_for_end_scope_at(end_line, content)
+    expect(node).to be_a(Expressir::Model::Declarations::Schema)
+  end
+
+  it "node_for_end_scope_at returns nil for a non-END line" do
+    line = source.lines.index { |l| l.include?("name : STRING") } + 1
+    expect(index.node_for_end_scope_at(line, source.lines[line - 1])).to be_nil
+  end
+
+  it "COLLECTION_REGISTRY lists Schema's collections" do
+    expect(described_class::COLLECTION_REGISTRY[Expressir::Model::Declarations::Schema])
+      .to include(:entities, :types, :functions)
+  end
+end

--- a/spec/expressir/express/scope_resolver_spec.rb
+++ b/spec/expressir/express/scope_resolver_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Expressir::Express::ScopeResolver do
+  let(:source) do
+    <<~EXP
+      SCHEMA demo;
+      ENTITY outer;
+      END_ENTITY;
+      TYPE color = ENUMERATION OF (red);
+      END_TYPE;
+      FUNCTION inner(name : STRING) : BOOLEAN;
+        RETURN(TRUE);
+      END_FUNCTION;
+      END_SCHEMA;
+    EXP
+  end
+
+  let(:exp_file) { Expressir::Express::Parser.from_exp(source) }
+  let(:line_map) { Expressir::Express::LineMap.new(source.b) }
+  let(:node_index) { Expressir::Express::NodePositionIndex.new(exp_file, line_map) }
+
+  def resolver
+    described_class.new(
+      source: source,
+      model: exp_file,
+      nodes_with_positions: node_index.nodes,
+    )
+  end
+
+  it "resolves a line inside an ENTITY to the entity" do
+    line = source.lines.index { |l| l.include?("ENTITY outer") } + 1
+    expect(resolver.containing_scope_for(line)).to be_a(Expressir::Model::Declarations::Entity)
+  end
+
+  it "resolves a line inside a FUNCTION to the function" do
+    line = source.lines.index { |l| l.include?("RETURN(TRUE)") } + 1
+    scope = resolver.containing_scope_for(line)
+    expect(scope).to be_a(Expressir::Model::Declarations::Function)
+    expect(scope.id).to eq("inner")
+  end
+
+  it "resolves a line before the SCHEMA to nil" do
+    expect(resolver.containing_scope_for(0)).to be_nil
+  end
+
+  it "find_by_source_text locates an entity by END_ENTITY boundary" do
+    end_line = source.lines.index { |l| l.include?("END_ENTITY") } + 1
+    scope = resolver.find_by_source_text(end_line)
+    expect(scope).to be_a(Expressir::Model::Declarations::Entity)
+    expect(scope.id).to eq("outer")
+  end
+
+  it "does not trip on a TYPE END when the open was an ENTITY" do
+    # Robustness against interleaved scopes (illegal in EXPRESS but the
+    # stack should not pop the wrong type).
+    end_type_line = source.lines.index { |l| l.include?("END_TYPE") } + 1
+    scope = resolver.find_by_source_text(end_type_line)
+    expect(scope).to be_a(Expressir::Model::Declarations::Type)
+  end
+end

--- a/spec/expressir/model/remark_format_spec.rb
+++ b/spec/expressir/model/remark_format_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Expressir::Model::RemarkFormat do
+  it "defines TAIL as 'tail'" do
+    expect(described_class::TAIL).to eq("tail")
+  end
+
+  it "defines EMBEDDED as 'embedded'" do
+    expect(described_class::EMBEDDED).to eq("embedded")
+  end
+
+  it "is the single source of truth referenced by RemarkInfo" do
+    info = Expressir::Model::RemarkInfo.new(text: "x", format: described_class::TAIL)
+    expect(info).to be_tail
+    expect(info).not_to be_embedded
+  end
+
+  it "is referenced by the scanner" do
+    remarks = Expressir::Express::RemarkScanner.new("-- hi\n").scan
+    expect(remarks.first.format).to eq(described_class::TAIL)
+  end
+end


### PR DESCRIPTION
## Summary

Architectural review of the remark pipeline surfaced three shallow modules and one duplicated vocabulary. This PR implements candidates #1, #2, and #3 from the review.

### Candidate #3 — Model::RemarkFormat vocabulary
- New `Expressir::Model::RemarkFormat` module with `TAIL` and `EMBEDDED` constants
- `RemarkInfo`, `RemarkScanner`, and `RemarkAttacher` all reference the model constants instead of bare `"tail"` / `"embedded"` literals
- Rename or extension lands in one place

### Candidate #2 — autoload instead of require_relative
- `lib/expressir/model.rb` no longer eagerly loads `concerns.rb`
- Each marker module (`HasId`, `HasRemarks`, `ScopeContainer`, etc.) is autoloaded from the same file (Ruby autoload just calls require; one file can define many constants)

### Candidate #1 — split the RemarkAttacher god class
- New `ScopeResolver`: one interface (`containing_scope_for`) hiding four strategies (O(1) name lookup, position fallback, source-text scan, schema-wide search)
- New `NodePositionIndex`: one interface (`nearest_node_to`, `node_for_end_scope_at`, `nodes`) hiding the tree walk + byte-to-line translation + nearest-node heuristics
- `RemarkAttacher` drops from **1074 to 616 lines** and now orchestrates two collaborators instead of inlining every concern
- `COLLECTION_REGISTRY` moves to `NodePositionIndex`; `RemarkAttacher` references it via the constant for its `collections_on` / `get_collection` helpers

## Architecture-review report

A self-contained HTML report covers all 8 candidates with before/after diagrams. This PR implements the three Strong recommendations. The remaining five are deferred for separate grills (Parser split, Formatter dispatch, Builder state, model_element source getter, marker-module consolidation).

## Test plan

- [x] New `scope_resolver_spec.rb` — 5 examples
- [x] New `node_position_index_spec.rb` — 6 examples
- [x] New `model/remark_format_spec.rb` — 4 examples
- [x] All 60 remark-related specs pass
- [x] 22 parser specs pass
- [x] Broader 834-example suite: 0 failures, 4 pre-existing pendings (CONSTANT grammar)
- [x] RuboCop clean on new and modified files
