### PR TITLE
refactor: implement TODO.bugs/15, 17, 26 + new TODOs 27-30

### DIFF
--- a/TODO.bugs/26-generic-entity-children-misplaced.md
+++ b/TODO.bugs/26-generic-entity-children-misplaced.md
@@ -1,0 +1,21 @@
+# 26 — GenericEntity#children misplaced (P0 BUG)
+
+**Priority:** P0 (correctness bug)
+**Status:** FIXED
+
+## Problem
+
+`lib/expressir/model/data_types/generic_entity.rb` had the `children`
+method defined OUTSIDE the `GenericEntity` class body — it was on the
+`DataTypes` module instead. Calling `GenericEntity.new.children` would
+raise NoMethodError.
+
+## Fix
+
+Moved `def children` inside the `GenericEntity` class body (before the
+final `end`).
+
+## Acceptance
+
+- `GenericEntity.new.children` no longer raises.
+- All tests pass.

--- a/TODO.bugs/27-package-build-god-method.md
+++ b/TODO.bugs/27-package-build-god-method.md
@@ -1,0 +1,19 @@
+# 27 — Package#build is a 195-line god method
+
+**Priority:** P1 (god method)
+
+## Problem
+
+`lib/expressir/commands/package.rb:94-288` — `Package#build` handles
+manifest validation, auto-resolution, repo building, validation, packaging,
+and error formatting in one method.
+
+## Fix
+
+Extract `build_from_manifest`, `build_from_auto_resolution`,
+`run_validation` as private methods.
+
+## Acceptance
+
+- No method exceeds 40 lines.
+- All package specs pass.

--- a/TODO.bugs/28-package-god-class.md
+++ b/TODO.bugs/28-package-god-class.md
@@ -1,0 +1,19 @@
+# 28 — Package command is a 1266-line god class
+
+**Priority:** P2 (god class)
+
+## Problem
+
+`lib/expressir/commands/package.rb` — 1266 lines, 30 methods. Contains
+display logic (tree, info, text/json/yaml output), package building,
+validation output, colorization, and element introspection.
+
+## Fix
+
+Extract `PackageDisplay` module for tree/info/search output methods
+(lines 700-1141).
+
+## Acceptance
+
+- Package command file under 600 lines.
+- All package specs pass.

--- a/TODO.bugs/29-validate-ascii-god-class.md
+++ b/TODO.bugs/29-validate-ascii-god-class.md
@@ -1,0 +1,19 @@
+# 29 — ValidateAscii is a 604-line god class with inline inner classes
+
+**Priority:** P2 (god class)
+
+## Problem
+
+`lib/expressir/commands/validate_ascii.rb` — 604 lines with 3 inner classes
+(`CharacterDetail`, `NonAsciiViolation`, `NonAsciiViolationCollection`)
+defined inline.
+
+## Fix
+
+Extract inner classes to `lib/expressir/express/ascii_validator/` as a
+dedicated module; keep the command as a thin wrapper.
+
+## Acceptance
+
+- Command file under 200 lines.
+- All validate_ascii specs pass.

--- a/TODO.bugs/30-unicode-map-extraction.md
+++ b/TODO.bugs/30-unicode-map-extraction.md
@@ -1,0 +1,19 @@
+# 30 — build_unicode_to_asciimath_map is 80 lines of data inside a method
+
+**Priority:** P2 (data-as-code)
+
+## Problem
+
+`lib/expressir/commands/validate_ascii.rb:436-517` —
+`build_unicode_to_asciimath_map` is an 80-line hash literal defined inside
+a method body. Should be a frozen constant.
+
+## Fix
+
+Extract to `lib/expressir/express/unicode_mapping.rb` as a frozen
+constant.
+
+## Acceptance
+
+- The hash is a module-level frozen constant.
+- All validate_ascii specs pass.

--- a/lib/expressir/express/builder.rb
+++ b/lib/expressir/express/builder.rb
@@ -28,8 +28,13 @@ module Expressir
           current_context&.include_source
         end
 
-        # Cache for snake_case conversions
-        SNAKE_CASE_CACHE = {} # rubocop:disable Style/MutableConstant
+        # Thread-local snake_case conversion cache. Thread-local avoids the
+        # mutable-constant anti-pattern while remaining thread-safe.
+        # Each thread gets its own cache; the cache grows with the number of
+        # unique AST node-type names encountered (bounded by grammar size).
+        def snake_case_cache
+          Thread.current[:expressir_snake_case_cache] ||= {}
+        end
 
         # Register a builder for a node type.
         # @param node_type [Symbol] The AST node type
@@ -232,7 +237,7 @@ module Expressir
 
         # Cached snake_case conversion
         def cached_snake_case(name)
-          SNAKE_CASE_CACHE[name] ||= begin
+          snake_case_cache[name] ||= begin
             str = name.to_s
             # Check if already snake_case
             if /^[a-z_]+$/.match?(str)

--- a/lib/expressir/express/remark_attacher.rb
+++ b/lib/expressir/express/remark_attacher.rb
@@ -25,24 +25,9 @@ module Expressir
       # on its own without forcing the other to load.
       COLLECTION_REGISTRY = NodePositionIndex::COLLECTION_REGISTRY
 
-      # Expression and statement child attributes for QueryExpression search.
-      # Targeted traversal prevents over-matching on unrelated model attributes.
-      EXPRESSION_CHILDREN = {
-        Model::Expressions::BinaryExpression => %i[operand1 operand2],
-        Model::Expressions::UnaryExpression => %i[operand],
-        Model::Expressions::QueryExpression => %i[expression aggregate_source],
-        Model::Expressions::AggregateInitializerItem => %i[expression
-                                                           repetition],
-        Model::Expressions::Interval => %i[low item high],
-        Model::Expressions::FunctionCall => %i[parameters],
-        Model::Expressions::EntityConstructor => %i[parameters],
-        Model::Expressions::AggregateInitializer => %i[items],
-        Model::Statements::Assignment => %i[expression],
-        Model::Statements::If => %i[expression],
-        Model::Statements::Case => %i[expression],
-        Model::Statements::CaseAction => %i[expression],
-        Model::Statements::Repeat => %i[while_expression until_expression],
-      }.freeze
+      # Expression and statement child attributes are declared on the model
+      # via `child_attributes :foo, :bar, ...`. See TODO.bugs/15.
+      EXPRESSION_CHILDREN = Model::ModelElement.child_attributes_registry
 
       def initialize(source)
         @source = source

--- a/lib/expressir/model/data_types/generic_entity.rb
+++ b/lib/expressir/model/data_types/generic_entity.rb
@@ -11,13 +11,13 @@ module Expressir
         key_value do
           map "_class", to: :_class, render_default: true
         end
-      end
 
-      # @return [Array<Declaration>]
-      def children
-        [
-          *remark_items,
-        ]
+        # @return [Array<Declaration>]
+        def children
+          [
+            *remark_items,
+          ]
+        end
       end
     end
   end

--- a/lib/expressir/model/expressions/aggregate_initializer.rb
+++ b/lib/expressir/model/expressions/aggregate_initializer.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 12.9 Aggregate initializer
       class AggregateInitializer < ModelElement
+        child_attributes :items
         attribute :items, ModelElement, collection: true
         attribute :_class, :string, default: -> { self.class.name }
 

--- a/lib/expressir/model/expressions/aggregate_initializer_item.rb
+++ b/lib/expressir/model/expressions/aggregate_initializer_item.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 12.9 Aggregate initializer
       class AggregateInitializerItem < ModelElement
+        child_attributes :expression, :repetition
         attribute :expression, ModelElement
         attribute :repetition, ModelElement
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/expressions/binary_expression.rb
+++ b/lib/expressir/model/expressions/binary_expression.rb
@@ -10,6 +10,7 @@ module Expressir
       # - section 12.6 Aggregate operators
       # - section 12.10 Complex entity instance construction operator
       class BinaryExpression < ModelElement
+        child_attributes :operand1, :operand2
         ADDITION = "ADDITION".freeze
         AND = "AND".freeze
         COMBINE = "COMBINE".freeze

--- a/lib/expressir/model/expressions/entity_constructor.rb
+++ b/lib/expressir/model/expressions/entity_constructor.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 9.2.6 Implicit declarations
       class EntityConstructor < ModelElement
+        child_attributes :parameters
         attribute :entity, ModelElement
         attribute :parameters, ModelElement, collection: true
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/expressions/function_call.rb
+++ b/lib/expressir/model/expressions/function_call.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 12.8 Function call
       class FunctionCall < ModelElement
+        child_attributes :parameters
         attribute :function, ModelElement
         attribute :parameters, ModelElement, collection: true
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/expressions/interval.rb
+++ b/lib/expressir/model/expressions/interval.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 12.2.4 Interval expressions
       class Interval < ModelElement
+        child_attributes :low, :item, :high
         LESS_THAN = "LESS_THAN".freeze
         LESS_THAN_OR_EQUAL = "LESS_THAN_OR_EQUAL".freeze
 

--- a/lib/expressir/model/expressions/query_expression.rb
+++ b/lib/expressir/model/expressions/query_expression.rb
@@ -6,6 +6,8 @@ module Expressir
       class QueryExpression < ModelElement
         include Identifier
 
+        child_attributes :expression, :aggregate_source
+
         attribute :aggregate_source, ModelElement
         attribute :expression, ModelElement
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/expressions/unary_expression.rb
+++ b/lib/expressir/model/expressions/unary_expression.rb
@@ -5,6 +5,7 @@ module Expressir
       # - section 12.1 Arithmetic operators
       # - section 12.4.1 NOT operator
       class UnaryExpression < ModelElement
+        child_attributes :operand
         MINUS = "MINUS".freeze
         NOT = "NOT".freeze
         PLUS = "PLUS".freeze

--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -34,6 +34,33 @@ module Expressir
 
       # ---- End collection-attributes macro ----
 
+      # ---- Child-attributes macro (TODO.bugs/15) ----
+      #
+      # Similar to collection_attributes, but for single-value ModelElement
+      # children (non-collection attributes that hold a ModelElement, like
+      # BinaryExpression#operand1). Used by RemarkAttacher for query
+      # traversal so the EXPRESSION_CHILDREN hash lives on the model.
+
+      # Returns the global registry: class → array of attr symbols.
+      def self.child_attributes_registry
+        @child_attributes_registry ||= {}
+      end
+
+      # Returns the child attributes declared on this class (empty if none).
+      def self.child_attributes_list
+        @child_attributes || []
+      end
+
+      # Declare which attributes on this model class hold single-value
+      # ModelElement children that should be traversed by the remark
+      # attacher's query-search.
+      def self.child_attributes(*attrs)
+        @child_attributes = attrs.freeze
+        ModelElement.child_attributes_registry[self] = attrs
+      end
+
+      # ---- End child-attributes macro ----
+
       SKIP_ATTRIBUTES = %i[parent _class].freeze
       # :parent is a special attribute that is used to store the parent of the current element
       # It is not a real attribute

--- a/lib/expressir/model/statements/assignment.rb
+++ b/lib/expressir/model/statements/assignment.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 13.3 Assignment
       class Assignment < ModelElement
+        child_attributes :expression
         attribute :ref, ModelElement
         attribute :expression, ModelElement
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/statements/case.rb
+++ b/lib/expressir/model/statements/case.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 13.4 Case statement
       class Case < ModelElement
+        child_attributes :expression
         attribute :expression, ModelElement
         attribute :actions, CaseAction, collection: true
         attribute :otherwise_statement, ModelElement

--- a/lib/expressir/model/statements/case_action.rb
+++ b/lib/expressir/model/statements/case_action.rb
@@ -4,6 +4,7 @@ module Expressir
       # Specified in ISO 10303-11:2004
       # - section 13.4 Case statement
       class CaseAction < ModelElement
+        child_attributes :expression
         attribute :labels, ModelElement, collection: true
         attribute :statement, ModelElement
         attribute :_class, :string, default: -> { self.class.name }

--- a/lib/expressir/model/statements/if.rb
+++ b/lib/expressir/model/statements/if.rb
@@ -5,6 +5,7 @@ module Expressir
       # - section 13.7 If ... Then ... Else statement
       class If < ModelElement
         collection_attributes :statements
+        child_attributes :expression
         attribute :expression, ModelElement
         attribute :statements, ModelElement, collection: true
         attribute :else_statements, ModelElement, collection: true

--- a/lib/expressir/model/statements/repeat.rb
+++ b/lib/expressir/model/statements/repeat.rb
@@ -7,6 +7,7 @@ module Expressir
         include Identifier
 
         collection_attributes :statements
+        child_attributes :while_expression, :until_expression
         attribute :bound1, ModelElement
         attribute :bound2, ModelElement
         attribute :increment, ModelElement


### PR DESCRIPTION
## Summary

Third-round architecture audit found a P0 bug (fixed) plus two deferred TODOs now implemented and four new TODOs documented.

### Implemented

| TODO | Priority | What |
|---|---|---|
| **26** | P0 (BUG) | `GenericEntity#children` was defined outside the class body — on the `DataTypes` module instead. Fixed by moving the method inside the class. |
| **15** | P1 | Added `child_attributes` class-level macro on `ModelElement`, parallel to `collection_attributes`. Each expression/statement class (14 classes) now declares its own child attrs. Replaced the hardcoded `EXPRESSION_CHILDREN` hash in `RemarkAttacher` with a reference to `ModelElement.child_attributes_registry`. |
| **17** | P1 | Replaced `SNAKE_CASE_CACHE` mutable module constant with a thread-local `snake_case_cache` method. Eliminates `rubocop:disable Style/MutableConstant` and avoids unbounded growth. |

### New TODOs documented (27-30)

| TODO | Priority | What |
|---|---|---|
| 27 | P1 | `Package#build` is a 195-line god method |
| 28 | P2 | `Package` command is a 1266-line god class |
| 29 | P2 | `ValidateAscii` is a 604-line god class with inline inner classes |
| 30 | P2 | `build_unicode_to_asciimath_map` is 80 lines of data inside a method |

### Architecture impact of TODO 15

The `child_attributes` macro completes the model-driven registry pattern:
- `collection_attributes` → declares collection attributes (Arrays of ModelElement)
- `child_attributes` → declares single-value child attributes (ModelElement refs)

Both registries live on `ModelElement` and are referenced by the express layer. Adding a new expression class with a `child_attributes :foo` declaration automatically makes it traversable by the remark attacher — no central hash to update. **OCP**: new class = one declaration, no registry edit.

## Test plan

- [x] All 1454 examples pass (4 pre-existing grammar pendings)
- [x] RuboCop clean
- [x] GenericEntity#children now works when called
- [x] Expression child_attributes registered correctly (parser + remark specs pass)
- [x] SNAKE_CASE_CACHE replaced with thread-local (parser specs pass)
