### PR TITLE
enhancement: add blank line between interface declarations (#155)

### DIFF
--- a/lib/expressir/express/formatters/declarations_formatter.rb
+++ b/lib/expressir/express/formatters/declarations_formatter.rb
@@ -525,7 +525,7 @@ module Expressir
             *if node.interfaces&.length&.positive?
                [
                  "",
-                 node.interfaces.map { |x| format(x) }.join("\n"),
+                 node.interfaces.map { |x| format(x) }.join("\n\n"),
                ]
              end,
           ].join("\n")

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -251,8 +251,10 @@ RSpec.describe Expressir::Express::Parser do
         SCHEMA multiple_schema;
 
         REFERENCE FROM multiple_schema2;
+
         REFERENCE FROM multiple_schema3
           (attribute_entity3);
+
         REFERENCE FROM multiple_schema4
           (attribute_entity AS attribute_entity4);
 

--- a/spec/expressir/model/model_element_spec.rb
+++ b/spec/expressir/model/model_element_spec.rb
@@ -137,19 +137,26 @@ RSpec.describe Expressir::Model::ModelElement do
         SCHEMA syntax_schema '{ISO standard 10303 part(41) object(1) version(8)}';
 
         USE FROM contract_schema;
+
         USE FROM contract_schema
           (contract);
+
         USE FROM contract_schema
           (contract,
            contract2);
+
         USE FROM contract_schema
           (contract AS contract2);
+
         REFERENCE FROM contract_schema;
+
         REFERENCE FROM contract_schema
           (contract);
+
         REFERENCE FROM contract_schema
           (contract,
            contract2);
+
         REFERENCE FROM contract_schema
           (contract AS contract2);
       TEXT

--- a/spec/syntax/multiple_formatted.exp
+++ b/spec/syntax/multiple_formatted.exp
@@ -1,8 +1,10 @@
 SCHEMA multiple_schema;
 
 REFERENCE FROM multiple_schema2;
+
 REFERENCE FROM multiple_schema3
   (attribute_entity3);
+
 REFERENCE FROM multiple_schema4
   (attribute_entity AS attribute_entity4);
 

--- a/spec/syntax/multiple_hyperlink_formatted.exp
+++ b/spec/syntax/multiple_hyperlink_formatted.exp
@@ -1,8 +1,10 @@
 SCHEMA multiple_schema;
 
 REFERENCE FROM multiple_schema2;
+
 REFERENCE FROM multiple_schema3
   (attribute_entity3);
+
 REFERENCE FROM multiple_schema4
   (attribute_entity AS attribute_entity4);
 

--- a/spec/syntax/multiple_schema_head_hyperlink_formatted.exp
+++ b/spec/syntax/multiple_schema_head_hyperlink_formatted.exp
@@ -1,8 +1,10 @@
 SCHEMA multiple_schema;
 
 REFERENCE FROM multiple_schema2;
+
 REFERENCE FROM multiple_schema3
   (attribute_entity3);
+
 REFERENCE FROM multiple_schema4
   (attribute_entity AS attribute_entity4);
 

--- a/spec/syntax/syntax_formatted.exp
+++ b/spec/syntax/syntax_formatted.exp
@@ -1,19 +1,26 @@
 SCHEMA syntax_schema '{ISO standard 10303 part(41) object(1) version(8)}';
 
 USE FROM contract_schema;
+
 USE FROM contract_schema
   (contract);
+
 USE FROM contract_schema
   (contract,
    contract2);
+
 USE FROM contract_schema
   (contract AS contract2);
+
 REFERENCE FROM contract_schema;
+
 REFERENCE FROM contract_schema
   (contract);
+
 REFERENCE FROM contract_schema
   (contract,
    contract2);
+
 REFERENCE FROM contract_schema
   (contract AS contract2);
 

--- a/spec/syntax/syntax_hyperlink_formatted.exp
+++ b/spec/syntax/syntax_hyperlink_formatted.exp
@@ -1,19 +1,26 @@
 SCHEMA syntax_schema '{ISO standard 10303 part(41) object(1) version(8)}';
 
 USE FROM contract_schema;
+
 USE FROM contract_schema
   (contract);
+
 USE FROM contract_schema
   (contract,
    contract2);
+
 USE FROM contract_schema
   (contract AS contract2);
+
 REFERENCE FROM contract_schema;
+
 REFERENCE FROM contract_schema
   (contract);
+
 REFERENCE FROM contract_schema
   (contract,
    contract2);
+
 REFERENCE FROM contract_schema
   (contract AS contract2);
 

--- a/spec/syntax/syntax_schema_head_formatted.exp
+++ b/spec/syntax/syntax_schema_head_formatted.exp
@@ -1,18 +1,25 @@
 SCHEMA syntax_schema '{ISO standard 10303 part(41) object(1) version(8)}';
 
 USE FROM contract_schema;
+
 USE FROM contract_schema
   (contract);
+
 USE FROM contract_schema
   (contract,
    contract2);
+
 USE FROM contract_schema
   (contract AS contract2);
+
 REFERENCE FROM contract_schema;
+
 REFERENCE FROM contract_schema
   (contract);
+
 REFERENCE FROM contract_schema
   (contract,
    contract2);
+
 REFERENCE FROM contract_schema
   (contract AS contract2);


### PR DESCRIPTION
Per Keith Hunten at WG 12 meeting (Seoul 2024-05-16). Each `USE FROM` and `REFERENCE FROM` declaration is now followed by a blank line.