### PR TITLE
fix: handle (*) overlap pattern in remarks (#126)

### DIFF
--- a/lib/expressir/express/grammar/parser.rb
+++ b/lib/expressir/express/grammar/parser.rb
@@ -256,7 +256,15 @@ module Expressir
           (expression >> (op_colon >> repetition).maybe).as(:element)
         end
         rule(:embeddedRemark) do
-          (str("(*") >> (str("*)").absent? >> (embeddedRemark | any)).repeat >> str("*)")).as(:embeddedRemark)
+          (
+            # `(*)` is a 3-character empty embedded remark: the opener `(*`
+            # and closer `*)` share the `*`. Per strict ISO 10303-11 §7.1.6
+            # grammar the opener and closer are distinct tokens and cannot
+            # share characters, so `(*)` is technically invalid. We accept
+            # it for robustness (issue #126).
+            str("(*)") |
+            (str("(*") >> (str("*)").absent? >> (embeddedRemark | any)).repeat >> str("*)"))
+          ).as(:embeddedRemark)
         end
         rule(:encodedCharacter) { octet >> octet >> octet >> octet }
         rule(:encodedStringLiteral) do

--- a/lib/expressir/express/remark_scanner.rb
+++ b/lib/expressir/express/remark_scanner.rb
@@ -45,6 +45,10 @@ module Expressir
       EMBEDDED_CLOSE = "*)"
       STRING_QUOTE = "'"
 
+      # Byte value of `)` — used to detect the `(*)` overlap pattern where
+      # the embedded-remark opener `(*` and closer `*)` share the `*`.
+      RPAREN_BYTE = ")".ord
+
       # Tag forms (see ISO 10303-11 §7.1.6.3 Remark tag).
       # IP-style informal-proposition tags are recognised only in tail remarks
       # (matching historic behaviour); embedded remarks use the quoted form.
@@ -67,6 +71,17 @@ module Expressir
       alias call scan
 
       private
+
+      # Detects the `(*)` overlap pattern: opener `(*` (positions pos, pos+1)
+      # and closer `*)` (positions pos+1, pos+2) share the `*` character.
+      # Per strict ISO 10303-11 §7.1.6 grammar the opener and closer are
+      # distinct tokens that cannot share characters, so `(*)` is technically
+      # invalid; we accept it as a 3-character empty embedded remark for
+      # robustness (issue #126).
+      def empty_overlap_remark?(pos)
+        pos + 2 < @source_bytes.bytesize &&
+          @source_bytes.getbyte(pos + 2) == RPAREN_BYTE
+      end
 
       def run_state_machine
         remarks = []
@@ -96,8 +111,13 @@ module Expressir
             closing = src.index(EMBEDDED_CLOSE, pos)
             nesting = src.index(EMBEDDED_OPEN, pos)
             if nesting && (!closing || nesting < closing)
-              embedded_depth += 1
-              pos = nesting + EMBEDDED_OPEN.bytesize
+              if empty_overlap_remark?(nesting)
+                # `(*)` opens and closes immediately; depth unchanged.
+                pos = nesting + 3
+              else
+                embedded_depth += 1
+                pos = nesting + EMBEDDED_OPEN.bytesize
+              end
             elsif closing
               embedded_depth -= 1
               pos = closing + EMBEDDED_CLOSE.bytesize
@@ -137,11 +157,21 @@ module Expressir
               pos = next_quote + STRING_QUOTE.bytesize
               state = :in_string
             elsif next_embed && (next_tail.nil? || next_embed <= next_tail)
-              embedded_start = next_embed + EMBEDDED_OPEN.bytesize
-              embedded_line = @line_map.line_number(next_embed)
-              embedded_depth = 1
-              state = :in_embedded
-              pos = next_embed + EMBEDDED_OPEN.bytesize
+              if empty_overlap_remark?(next_embed)
+                # Standalone `(*)`: empty embedded remark, opener and closer
+                # share the `*`. Emit with empty content and continue.
+                emit_embedded(remarks, next_embed + EMBEDDED_OPEN.bytesize,
+                              next_embed + EMBEDDED_OPEN.bytesize,
+                              @line_map.line_number(next_embed))
+                pos = next_embed + 3
+                state = :top
+              else
+                embedded_start = next_embed + EMBEDDED_OPEN.bytesize
+                embedded_line = @line_map.line_number(next_embed)
+                embedded_depth = 1
+                state = :in_embedded
+                pos = next_embed + EMBEDDED_OPEN.bytesize
+              end
             else
               tail_start = next_tail + TAIL_MARKER.bytesize
               tail_line = @line_map.line_number(next_tail)

--- a/spec/expressir/express/parser_spec.rb
+++ b/spec/expressir/express/parser_spec.rb
@@ -500,4 +500,27 @@ RSpec.describe Expressir::Express::Parser do
       expect(schemas[4].id).to eq("multiple_schema4")
     end
   end
+
+  describe "issue #126: `(*)` pattern in remarks" do
+    # `(*)` overlaps the embedded-remark opener `(*` and closer `*)` at the
+    # `*` character. The parser must accept it (as an empty embedded remark)
+    # instead of failing or terminating the enclosing remark early.
+    it "parses a schema with `(*)` inside an embedded remark" do
+      source = "SCHEMA s; (* test (*) here *) END_SCHEMA;\n"
+
+      expect { described_class.from_exp(source) }.not_to raise_error
+    end
+
+    it "parses a schema with standalone `(*)`" do
+      source = "SCHEMA s; (*) END_SCHEMA;\n"
+
+      expect { described_class.from_exp(source) }.not_to raise_error
+    end
+
+    it "parses a schema with multiple `(*)` inside one remark" do
+      source = "SCHEMA s; (* a (*) b (*) c *) END_SCHEMA;\n"
+
+      expect { described_class.from_exp(source) }.not_to raise_error
+    end
+  end
 end

--- a/spec/expressir/express/remark_scanner_spec.rb
+++ b/spec/expressir/express/remark_scanner_spec.rb
@@ -254,6 +254,50 @@ RSpec.describe Expressir::Express::RemarkScanner do
     end
   end
 
+  describe "issue #126: `(*)` overlap pattern" do
+    # `(*)` is a 3-char pattern where the embedded-remark opener `(*` and the
+    # closer `*)` share the `*` character. Per strict ISO 10303-11 §7.1.6
+    # grammar the opener and closer are distinct tokens that cannot share
+    # characters, so `(*)` is technically invalid; we accept it as a 3-char
+    # empty embedded remark for robustness.
+    it "extracts `(*)` alone as an empty embedded remark" do
+      remarks = scan("(*)")
+
+      expect(remarks.size).to eq(1)
+      expect(remarks.first).to be_embedded
+      expect(remarks.first.text).to eq("")
+    end
+
+    it "preserves an outer remark when `(*)` appears inside it" do
+      remarks = scan("(* test (*) here *)")
+
+      expect(remarks.size).to eq(1)
+      expect(remarks.first).to be_embedded
+      expect(remarks.first.text).to eq("test (*) here")
+    end
+
+    it "handles multiple `(*)` patterns inside one remark" do
+      remarks = scan("(* before (*) after (*) end *)")
+
+      expect(remarks.size).to eq(1)
+      expect(remarks.first.text).to eq("before (*) after (*) end")
+    end
+
+    it "treats `(*)` as empty nested inside a tagged embedded remark" do
+      remarks = scan('(*"tag" content (*) content *)')
+
+      expect(remarks.size).to eq(1)
+      expect(remarks.first.tag).to eq("tag")
+      expect(remarks.first.text).to eq("content (*) content")
+    end
+
+    it "still recognises `(* *)` and `(**)` as ordinary embedded remarks" do
+      expect(scan("(* *)").first.text).to eq("")
+      expect(scan("(**)").first.text).to eq("")
+      expect(scan("(* a (**) c *)").first.text).to eq("a (**) c")
+    end
+  end
+
   describe "source-order and positions" do
     it "returns remarks ordered by byte position" do
       source = "-- one\n(* two *)\n-- three\n"


### PR DESCRIPTION
Fixes #126.

## Problem

The `(*)` 3-character sequence is an overlapping case where the embedded-remark opener `(*` and closer `*)` share the `*` character at the middle position. Per strict ISO 10303-11 §7.1.6 grammar the opener and closer are distinct tokens that cannot share characters, so `(*)` is technically invalid — but real-world schemas sometimes contain this pattern (e.g. wildcards in remark tags).

Previously:
- The parser **failed** to parse any schema containing `(*)` inside an embedded remark.
- The RemarkScanner mishandled the overlap, swallowing the outer `*)` as the nested closer and returning zero remarks.

## Fix

Accept `(*)` as a 3-character empty embedded remark for robustness.

```ruby
rule(:embeddedRemark) do
  (
    str("(*)") |  # overlap form: opener and closer share `*`
    (str("(*") >> (str("*)").absent? >> (embeddedRemark | any)).repeat >> str("*)"))
  ).as(:embeddedRemark)
end
```

The RemarkScanner mirrors this in both its `top` and `in_embedded` states via a new `empty_overlap_remark?` helper.

## Coverage

- Scanner specs: `(*)` alone, inside another remark, multiple `(*)` in sequence, inside tagged remarks, and unchanged behavior for `(* *)`/`(**)`.
- Parser specs: schema with `(*)` standalone, inside an embedded remark, and multiple `(*)` in one remark.

All 1457+ tests pass. RuboCop clean.