### PR TITLE
fix: differentiate embedded vs tail remarks in validate ascii (#285)

### DIFF
--- a/lib/expressir/commands/non_ascii_violation_collection.rb
+++ b/lib/expressir/commands/non_ascii_violation_collection.rb
@@ -133,7 +133,7 @@ module Expressir
         end
 
         # Always print summary
-        validation_scope = @check_remarks ? "code and remarks" : "code only (remarks excluded)"
+        validation_scope = @check_remarks ? "code and all remarks" : "code and tail remarks (embedded remarks excluded)"
         puts "\n#{Paint['Summary:', :blue, :bold]}"
         puts "  #{Paint['Validation scope:',
                         :green]} #{Paint[validation_scope,
@@ -197,100 +197,53 @@ module Expressir
 
       private
 
-      def process_file_violations(file)
-        file_violations = FileViolations.new(file)
+      # Build a masked copy of `source` where every byte inside an embedded
+      # remark region is replaced with an ASCII space. Byte positions and the
+      # string's encoding are preserved, so masked lines still align 1:1 with
+      # the original file for reporting.
+      def mask_embedded_remarks(source)
+        remarks = Expressir::Express::RemarkScanner.new(source).scan
+        embedded = remarks.select(&:embedded?)
+        return source if embedded.empty?
 
-        if @check_remarks
-          # Check remarks too - validate original file content
-          File.readlines(file,
-                         encoding: "UTF-8").each_with_index do |line, line_idx|
-            line_number = line_idx + 1
-
-            # Skip if line only contains ASCII
-            next unless /[^\x00-\x7F]/.match?(line)
-
-            # Find all non-ASCII sequences
-            line.chomp.scan(/([^\x00-\x7F]+)/) do |match|
-              match = match[0]
-              column = line.index(match)
-
-              # Process each character in the sequence
-              char_details = match.chars.filter_map do |c|
-                process_non_ascii_char(c)
-              end
-
-              # Skip if no non-ASCII characters found
-              next if char_details.empty?
-
-              file_violations.add_violation(line_number, column, match,
-                                            char_details, line.chomp)
-            end
-          end
-        else
-          # Default: exclude remarks - use model-based approach
-          # Parse the EXPRESS file to get the model
-          repository = Expressir::Express::Parser.from_file(file)
-
-          # Format each schema without remarks to get plain EXPRESS code
-          repository.schemas.each do |schema|
-            formatted_schema = schema.format(no_remarks: true)
-
-            # Check the formatted schema (without remarks) for non-ASCII
-            formatted_schema.lines.each_with_index do |line, line_idx|
-              line_number = line_idx + 1
-
-              # Skip if line only contains ASCII
-              next unless /[^\x00-\x7F]/.match?(line)
-
-              # Find all non-ASCII sequences
-              line.chomp.scan(/([^\x00-\x7F]+)/) do |match|
-                match = match[0]
-                column = line.index(match)
-
-                # Process each character in the sequence
-                char_details = match.chars.filter_map do |c|
-                  process_non_ascii_char(c)
-                end
-
-                # Skip if no non-ASCII characters found
-                next if char_details.empty?
-
-                file_violations.add_violation(line_number, column, match,
-                                              char_details, line.chomp)
-              end
-            end
-          end
+        masked = source.b.dup
+        embedded.each do |r|
+          (r.position...r.end_position).each { |i| masked.setbyte(i, 0x20) }
         end
+        masked.force_encoding(source.encoding)
+      end
 
-        file_violations
-      rescue Expressir::Express::Error::SchemaParseFailure
-        # If file can't be parsed, fall back to checking original content
-        # This ensures we still catch non-ASCII even in invalid EXPRESS
-        File.readlines(file,
-                       encoding: "UTF-8").each_with_index do |line, line_idx|
+      def scan_lines_for_non_ascii(file_violations, lines)
+        lines.each_with_index do |line, line_idx|
           line_number = line_idx + 1
-
-          # Skip if line only contains ASCII
           next unless /[^\x00-\x7F]/.match?(line)
 
-          # Find all non-ASCII sequences
           line.chomp.scan(/([^\x00-\x7F]+)/) do |match|
             match = match[0]
             column = line.index(match)
 
-            # Process each character in the sequence
             char_details = match.chars.filter_map do |c|
               process_non_ascii_char(c)
             end
-
-            # Skip if no non-ASCII characters found
             next if char_details.empty?
 
             file_violations.add_violation(line_number, column, match,
                                           char_details, line.chomp)
           end
         end
+      end
 
+      def process_file_violations(file)
+        file_violations = FileViolations.new(file)
+        source = File.read(file, encoding: "UTF-8")
+
+        # With --check-remarks: scan every line including embedded remarks.
+        # Without: scan code + tail remarks only — mask out embedded remark
+        # regions so non-ASCII inside `(* ... *)` documentation blocks is
+        # not flagged. Tail remarks (`--`) are part of code lines and stay
+        # in scope (issue #285).
+        scan_source = @check_remarks ? source : mask_embedded_remarks(source)
+        scan_lines_for_non_ascii(file_violations, scan_source.lines)
         file_violations
       end
 

--- a/lib/expressir/express/remark_scanner.rb
+++ b/lib/expressir/express/remark_scanner.rb
@@ -25,7 +25,13 @@ module Expressir
     #                    §7.1.6.5). `--` and `(*` inside a string are content.
     class RemarkScanner
       # Immutable value object describing a single extracted remark.
-      Remark = Struct.new(:position, :line, :text, :tag, :format, keyword_init: true) do
+      # `position` is the byte offset of the opener (`--` or `(*`).
+      # `end_position` is the byte offset one past the closer (the newline
+      # byte for tail remarks, the byte after `*)` for embedded remarks).
+      # `[position, end_position)` is the full byte range the remark
+      # occupied in the original source.
+      Remark = Struct.new(:position, :end_position, :line, :text, :tag,
+                          :format, keyword_init: true) do
         def tail?
           format == Model::RemarkFormat::TAIL
         end
@@ -36,6 +42,11 @@ module Expressir
 
         def tagged?
           !tag.nil? && !tag.empty?
+        end
+
+        # Byte length of the full remark (opener + content + closer).
+        def bytesize
+          end_position - position
         end
       end
 
@@ -161,6 +172,7 @@ module Expressir
         tag, content = parse_tail(raw.strip)
         remarks << Remark.new(
           position: content_start - TAIL_MARKER.bytesize,
+          end_position: content_end,
           line: line,
           text: content,
           tag: tag,
@@ -173,6 +185,7 @@ module Expressir
         tag, content = parse_embedded(raw)
         remarks << Remark.new(
           position: content_start - EMBEDDED_OPEN.bytesize,
+          end_position: content_end + EMBEDDED_CLOSE.bytesize,
           line: line,
           text: content,
           tag: tag,

--- a/spec/expressir/commands/validate_ascii_spec.rb
+++ b/spec/expressir/commands/validate_ascii_spec.rb
@@ -80,16 +80,17 @@ RSpec.describe Expressir::Commands::ValidateAscii do
     context "with check_remarks option" do
       let(:fixtures_dir) { "spec/fixtures/validate_ascii" }
 
-      it "excludes remarks by default (check_remarks: false)" do
+      it "scans tail remarks by default but skips embedded remarks (check_remarks: false)" do
         command.run("#{fixtures_dir}/non_ascii_in_remarks_only.exp")
 
-        # Should NOT find violations since Unicode is only in remarks
-        expect(output.string).to include("Found")
-        expect(output.string).to include("0")
-        expect(output.string).to include("non-ASCII sequence(s)")
+        # Tail remarks (`--`) are part of code lines and stay in scope (issue #285).
+        # Embedded remarks (`(* ... *)`) are excluded by default.
+        expect(output.string).to include("non-ASCII sequence")
+        expect(output.string).to include("non-ASCII sequence(s) in")
+        expect(output.string).not_to include("0\n")
       end
 
-      it "includes remarks when check_remarks is true" do
+      it "includes both tail and embedded remarks when check_remarks is true" do
         command_with_check = described_class.new(check_remarks: true)
 
         command_with_check.run("#{fixtures_dir}/non_ascii_in_remarks_only.exp")
@@ -117,16 +118,17 @@ RSpec.describe Expressir::Commands::ValidateAscii do
     context "with fixture files" do
       let(:fixtures_dir) { "spec/fixtures/validate_ascii" }
 
-      it "passes validation for file with non-ASCII only in remarks" do
+      it "detects tail-remark violations by default for file with non-ASCII only in remarks" do
         command.run("#{fixtures_dir}/non_ascii_in_remarks_only.exp")
 
-        # Should NOT find violations since Unicode is only in remarks
+        # Tail remarks are scanned; embedded remarks are not.
         expect(output.string).to include("Scanned")
         expect(output.string).to include("1")
         expect(output.string).to include("EXPRESS file(s)")
         expect(output.string).to include("Found")
-        expect(output.string).to include("0")
-        expect(output.string).to include("non-ASCII sequence(s)")
+        # Should find at least one tail-remark violation (e.g. -- Japanese: 日本語)
+        expect(output.string).to include("non-ASCII sequence(s) in")
+        expect(output.string).to include("1")
       end
 
       it "detects violations in file with non-ASCII in code" do
@@ -140,15 +142,15 @@ RSpec.describe Expressir::Commands::ValidateAscii do
         expect(output.string).to include("μ")
       end
 
-      it "detects only code violations in file with non-ASCII in both" do
+      it "detects code and tail-remark violations in file with non-ASCII in both" do
         command.run("#{fixtures_dir}/non_ascii_in_both.exp")
 
-        # Should detect violations in code but not in remarks
+        # Default scope: code + tail remarks. Should detect code violations
+        # and tail-remark violations, but skip embedded-remark text.
         expect(output.string).to include("non-ASCII sequence")
         expect(output.string).to include("価格") # Code violation
         expect(output.string).to include("π") # Code violation
 
-        # Remarks should be excluded, so count should be less than total Unicode chars
         violation_count = output.string.scan("non-ASCII sequence").size
         expect(violation_count).to be > 0
         expect(violation_count).to be < 10 # Should be much less than all Unicode chars including remarks
@@ -176,24 +178,24 @@ RSpec.describe Expressir::Commands::ValidateAscii do
         expect(output.string).to include("\"00006238\"")
       end
 
-      it "excludes non-ASCII characters in tail remarks" do
+      it "detects non-ASCII characters in tail remarks by default (issue #285)" do
         temp_file.write("SCHEMA test_schema;\nENTITY test_entity;\n  name : STRING; -- 神戸 Japanese characters\nEND_ENTITY;\nEND_SCHEMA;\n")
         temp_file.close
 
         command.run(temp_file.path)
 
-        # Should NOT detect 神戸 in tail remark (model-based formatting removes it)
-        expect(output.string).not_to include("神")
-        expect(output.string).not_to include("戸")
+        # Tail remarks are part of code lines and stay in scope by default.
+        expect(output.string).to include("神")
+        expect(output.string).to include("戸")
       end
 
-      it "excludes non-ASCII characters in embedded remarks" do
+      it "excludes non-ASCII characters in embedded remarks by default" do
         temp_file.write("SCHEMA test_schema;\nENTITY (* comment with 中文字 *) test_entity;\n  name : STRING;\nEND_ENTITY;\nEND_SCHEMA;\n")
         temp_file.close
 
         command.run(temp_file.path)
 
-        # Should NOT detect 中文字 in embedded remark (model-based formatting removes it)
+        # Should NOT detect 中文字 in embedded remark (default scope excludes embedded)
         expect(output.string).not_to include("中")
         expect(output.string).not_to include("文")
         expect(output.string).not_to include("字")


### PR DESCRIPTION
Fixes #285.

## Problem

The `validate ascii` command treated all remarks the same — without `--check-remarks` it stripped **both** tail (`--`) and embedded (`(* ... *)`) remarks before scanning. So a non-ASCII char in a tail comment (e.g. `-- 製品`) was silently ignored.

The user in issue #285 expected the default to find non-ASCII in tail remarks because tail remarks are part of code lines.

## Fix

Distinguish the two remark kinds:

| Scope | What is scanned |
|-------|-----------------|
| Default | code + **tail** remarks |
| `--check-remarks` | code + tail + **embedded** remarks |

Embedded remark regions (`(* ... *)`) are masked out using `RemarkScanner` when `--check-remarks` is off; tail remarks (`--`) are part of code lines and stay in scope.

## Implementation

1. Added `end_position` and `bytesize` to `RemarkScanner::Remark` so callers can identify the full byte range of any remark (the scanner is the source of truth for remark regions).
2. `NonAsciiViolationCollection#process_file_violations` now reads the original source (no formatter round-trip) and masks out bytes inside embedded remark regions when `--check-marks` is off. The old formatter-based path is removed — simpler and faster.
3. Updated `validate_ascii_spec.rb` to assert the new default behavior; verified with the exact example from the issue.

## Verification

Running on the issue's example schema:

```
$ bundle exec exe/expressir validate ascii foo_schema.exp
Found 1 non-ASCII sequence(s) in 1 file(s)   # ♪ in tail remark

$ bundle exec exe/expressir validate ascii --check-remarks foo_schema.exp
Found 2 non-ASCII sequence(s) in 1 file(s)   # ♪ + π in embedded remark
```

All 26 validate_ascii specs pass. RuboCop clean.