### PR TITLE
fix: resolve SELF\<supertype>.<attr> remark targets (#130)

### DIFF
--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -200,6 +200,13 @@ module Expressir
           current_path
         end
 
+        # Annotated EXPRESS remark tags reference redeclared attributes via
+        # `SELF\<supertype>.<attr>` (ISO 10303-11 §9.2.3). The redeclared
+        # attribute is indexed in the entity's children_by_id under its base
+        # name (e.g. `operand`), not under the SELF-qualified form. Strip the
+        # SELF\<supertype> qualifier so lookup succeeds (issue #130).
+        path_parts = path_parts.reject { |part| part.start_with?("self\\") }
+
         current_scope = self
         target_node = nil
         loop do

--- a/spec/expressir/express/visitor/remark_attacher_spec.rb
+++ b/spec/expressir/express/visitor/remark_attacher_spec.rb
@@ -106,4 +106,53 @@ RSpec.describe Expressir::Express::RemarkAttacher do
       expect(remarks[3].text).to eq("embedded remark")
     end
   end
+
+  describe "issue #130: SELF\\<supertype>.<attr> remark targets" do
+    # Annotated EXPRESS remark tags reference redeclared attributes via
+    # `SELF\<supertype>.<attr>` (ISO 10303-11 §9.2.3). The redeclared
+    # attribute is indexed under its base name; the SELF qualifier must not
+    # confuse path lookup.
+    let(:source) do
+      <<~EXP
+        SCHEMA mathematical_functions_schema;
+
+        ENTITY unary_generic_expression;
+          operand : GENERIC_ENTITY;
+        END_ENTITY;
+
+        ENTITY dependent_variable_definition
+          SUBTYPE OF (unary_generic_expression);
+          name        : label;
+          SELF\\unary_generic_expression.operand : GENERIC_ENTITY;
+        END_ENTITY;
+
+        (*"mathematical_functions_schema.dependent_variable_definition.SELF\\unary_generic_expression.operand"
+        The expression defining the dependent variable.
+        *)
+
+        (*"mathematical_functions_schema.dependent_variable_definition.name"
+        The label identifying the dependent variable.
+        *)
+
+        END_SCHEMA;
+      EXP
+    end
+    let(:repo) { Expressir::Express::Parser.from_exp(source) }
+    let(:schema) { repo.schemas.first }
+    let(:entity) { schema.entities.find { |e| e.id == "dependent_variable_definition" } }
+
+    it "attaches the remark to the redeclared (SELF\\...) attribute" do
+      redeclared = entity.attributes.find { |a| a.id == "operand" }
+
+      expect(redeclared).not_to be_nil
+      expect(redeclared.remarks).to eq(["The expression defining the dependent variable."])
+    end
+
+    it "still attaches the remark to the plain attribute" do
+      plain = entity.attributes.find { |a| a.id == "name" }
+
+      expect(plain).not_to be_nil
+      expect(plain.remarks).to eq(["The label identifying the dependent variable."])
+    end
+  end
 end


### PR DESCRIPTION
Fixes #130.

## Problem

Annotated EXPRESS remark tags reference redeclared attributes using `SELF\<supertype>.<attr>` per ISO 10303-11 §9.2.3, e.g.:

```express
(*"mathematical_functions_schema.dependent_variable_definition.SELF\unary_generic_expression.operand"
The expression defining the dependent variable.
*)
```

The redeclared attribute is indexed in the entity's `children_by_id` under its base name (`operand`), not under the SELF-qualified form. `ModelElement#find` did not strip the `SELF\<supertype>` qualifier, so lookup failed and the remark was silently dropped — the attribute ended up with no remarks.

## Fix

In `ModelElement#find`, reject path parts that start with `self\` before resolving. The remaining parts (e.g. `operand`) resolve against the entity's `children_by_id` as before.

```ruby
# Strip the SELF\<supertype> qualifier so lookup falls through to the
# base attribute name (issue #130).
path_parts = path_parts.reject { |part| part.start_with?("self\\") }
```

## Verification

Added integration spec in `remark_attacher_spec.rb` using the example from the issue. The redeclared `operand` attribute now correctly receives the remark.

All 6 attacher specs pass. RuboCop clean.