### PR TITLE
fix: disambiguate SELF\<supertype>.<attr> by supertype (#267)

### DIFF
--- a/lib/expressir/model/model_element.rb
+++ b/lib/expressir/model/model_element.rb
@@ -200,26 +200,12 @@ module Expressir
           current_path
         end
 
-        # Annotated EXPRESS remark tags reference redeclared attributes via
-        # `SELF\<supertype>.<attr>` (ISO 10303-11 §9.2.3). The redeclared
-        # attribute is indexed in the entity's children_by_id under its base
-        # name (e.g. `operand`), not under the SELF-qualified form. Strip the
-        # SELF\<supertype> qualifier so lookup succeeds (issue #130).
-        path_parts = path_parts.reject { |part| part.start_with?("self\\") }
-
         current_scope = self
         target_node = nil
         loop do
-          # find in current scope
-          current_node = current_scope
-          path_parts.each do |current_path|
-            current_node = current_node.children_by_id[current_path]
-            break unless current_node
-          end
-          target_node = current_node
+          target_node = resolve_path_in_scope(current_scope, path_parts)
           break if target_node
 
-          # retry search in parent scope
           current_scope = current_scope.parent
           break unless current_scope
         end
@@ -229,6 +215,62 @@ module Expressir
         end
 
         target_node
+      end
+
+      # Walk `path_parts` through `scope`, resolving one part at a time.
+      # Handles `SELF\<supertype>.<attr>` qualifiers inline: when a part
+      # starts with `self\`, the next part is matched against the scope's
+      # redeclared attributes and disambiguated by the supertype name
+      # (issues #130 and #267).
+      def resolve_path_in_scope(scope, path_parts)
+        current_node = scope
+        pending_supertype = nil
+
+        path_parts.each do |current_path|
+          if current_path.start_with?("self\\")
+            pending_supertype = current_path.split("\\", 2).last
+            next
+          end
+
+          if pending_supertype
+            child = find_redeclared_by_supertype(current_node, current_path,
+                                                 pending_supertype)
+            return nil unless child
+
+            current_node = child
+            pending_supertype = nil
+          else
+            current_node = current_node.children_by_id[current_path]
+            return nil unless current_node
+          end
+        end
+
+        # If the path ended on a SELF qualifier (no attr name followed),
+        # resolution is incomplete.
+        pending_supertype ? nil : current_node
+      end
+
+      # Find a redeclared attribute among `scope`'s children whose id matches
+      # `attr_name` and whose supertype_attribute references the given
+      # `supertype` name. Returns nil if `scope` is not an Attribute container
+      # or no such child exists.
+      def find_redeclared_by_supertype(scope, attr_name, supertype)
+        attrs = scope.respond_to?(:attributes) ? scope.attributes : nil
+        return nil unless attrs
+
+        attrs.find do |child|
+          next false unless child.is_a?(Model::Declarations::Attribute)
+          next false unless child.id&.safe_downcase == attr_name
+
+          supertype_attr = child.supertype_attribute
+          next false unless supertype_attr.respond_to?(:ref)
+
+          group_ref = supertype_attr.ref
+          next false unless group_ref.respond_to?(:entity)
+
+          entity_ref = group_ref.entity
+          entity_ref&.id&.safe_downcase == supertype
+        end
       end
 
       # @return [Array<Declaration>]

--- a/spec/expressir/express/visitor/remark_attacher_spec.rb
+++ b/spec/expressir/express/visitor/remark_attacher_spec.rb
@@ -155,4 +155,53 @@ RSpec.describe Expressir::Express::RemarkAttacher do
       expect(plain.remarks).to eq(["The label identifying the dependent variable."])
     end
   end
+
+  describe "issue #267: two redeclared attributes with same base name" do
+    # When an entity redeclares the same attribute name from multiple
+    # supertypes, each `SELF\<supertype>.<attr>` remark tag must attach to
+    # the specific redeclared attribute (matched by supertype qualifier),
+    # not collapse onto a single one.
+    let(:source) do
+      <<~EXP
+        SCHEMA parameterization_schema;
+
+        ENTITY maths_variable;
+          name : label;
+        END_ENTITY;
+
+        ENTITY representation_item;
+          name : label;
+        END_ENTITY;
+
+        ENTITY variational_parameter
+          SUBTYPE OF (maths_variable, representation_item);
+          SELF\\maths_variable.name : label;
+          SELF\\representation_item.name : label;
+        END_ENTITY;
+
+        (*"parameterization_schema.variational_parameter.SELF\\maths_variable.name"
+        The maths_variable name.
+        *)
+
+        (*"parameterization_schema.variational_parameter.SELF\\representation_item.name"
+        The representation_item name.
+        *)
+
+        END_SCHEMA;
+      EXP
+    end
+    let(:repo) { Expressir::Express::Parser.from_exp(source) }
+    let(:schema) { repo.schemas.first }
+    let(:entity) { schema.entities.find { |e| e.id == "variational_parameter" } }
+
+    it "attaches each remark to the matching redeclared attribute" do
+      maths_attr, repr_attr = entity.attributes
+
+      expect(maths_attr.supertype_attribute.ref.entity.id).to eq("maths_variable")
+      expect(repr_attr.supertype_attribute.ref.entity.id).to eq("representation_item")
+
+      expect(maths_attr.remarks).to eq(["The maths_variable name."])
+      expect(repr_attr.remarks).to eq(["The representation_item name."])
+    end
+  end
 end


### PR DESCRIPTION
Fixes #267. Follow-up to #325 (#130).

## Problem

When an entity redeclares the same attribute name from multiple supertypes:

```express
ENTITY variational_parameter
  SUBTYPE OF (maths_variable, representation_item);
  SELF\maths_variable.name : label;
  SELF\representation_item.name : label;
END_ENTITY;

(*"...variational_parameter.SELF\maths_variable.name" ... *)
(*"...variational_parameter.SELF\representation_item.name" ... *)
```

`#find` (after #130) collapsed both remarks onto a single `name` attribute because `children_by_id["name"]` only points at one. The supertype qualifier was being stripped without being used to disambiguate.

## Fix

`ModelElement#find` now resolves `SELF\<supertype>.<attr>` qualifiers inline:

- When walking the path, a `self\<supertype>` part stores the qualifier.
- The next part is matched against the scope's `attributes` by both `id` AND `supertype_attribute.ref.entity.id`, so the correct redeclared attribute is selected.
- If no attribute matches the qualifier, lookup falls through (returns nil rather than attaching to the wrong attribute).

## Verification

Spec added to `remark_attacher_spec.rb` with the exact scenario from the issue. Both redeclared `name` attributes correctly receive their distinct remarks.

All 789 model+parser+attacher specs pass. RuboCop clean.