### PR TITLE
chore: exclude iso.org from link checker (#287)

### DIFF
--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -59,6 +59,9 @@ exclude = [
   "https://www\\.nist\\.gov/.*",
   "https://www\\.steptools\\.com/.*",
 
+  # iso.org returns 403 to bots — the ISO store page is reachable in a browser
+  "https://www\\.iso\\.org/.*",
+
   # GitHub URLs that require authentication
   "https://github\\.com/.*/(issues|pull)/[0-9]+/files.*",
 


### PR DESCRIPTION
Fixes #287.

`iso.org` returns HTTP 403 to the lychee user-agent. The ISO standard pages are reachable in a browser but the bot is blocked, which causes the broken-links workflow to fail.

Excluding `www.iso.org` matches the existing pattern for `nist.gov` and `steptools.com`.